### PR TITLE
[TOOLS-2655] Add link to backward transfer page in nav

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -62,6 +62,13 @@
                     "data-test": "forward_transfers_link",
                     to: forward_transfer_path(@conn, :index)
                   ) %>
+                
+              <%= link(
+                    gettext("Backward Transfers"),
+                    class: "dropdown-item #{tab_status(BlockScoutWeb.TransactionView.backward_transfer_address(), @conn.request_path)}",
+                    "data-test": "backward_transfers_link",
+                    to: "/address/#{BlockScoutWeb.TransactionView.backward_transfer_address()}"
+                  ) %>
 
               <%= link(
                     gettext("Fee Payments"),

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
@@ -430,6 +430,10 @@ defmodule BlockScoutWeb.TransactionView do
     to_string(hash)
   end
 
+  def backward_transfer_address() do
+    @backward_transfer_address
+  end
+
   def backward_transfer?(%Transaction{to_address: to_address}) do
    to_string(to_address) == @backward_transfer_address
   end


### PR DESCRIPTION
### Ticket

- [TOOLS-2655 Blockscout: Add link to backward transfer page in nav"](https://horizenlabs.atlassian.net/browse/TOOLS-2655)

### Changes

- feat: add link to backward transfer page in nav

### Preview
<img width="997" alt="image" src="https://github.com/HorizenLabs/eon-explorer/assets/36055057/a21dac44-55bb-4509-aa2f-231767d76658">



