### PR TITLE
feat:enable internal tx indexing

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
@@ -89,8 +89,6 @@ defmodule EthereumJSONRPC.Geth do
   @tracer File.read!(@tracer_path)
 
   defp debug_trace_transaction_request(%{id: id, hash_data: hash_data}) do
-    debug_trace_transaction_timeout =
-      Application.get_env(:ethereum_jsonrpc, __MODULE__)[:debug_trace_transaction_timeout]
 
     tracer =
       case Application.get_env(:ethereum_jsonrpc, __MODULE__)[:tracer] do
@@ -112,7 +110,7 @@ defmodule EthereumJSONRPC.Geth do
     request(%{
       id: id,
       method: "debug_traceTransaction",
-      params: [hash_data, %{timeout: debug_trace_transaction_timeout} |> Map.merge(tracer)]
+      params: [hash_data, tracer]
     })
   end
 

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -22,8 +22,9 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
   @behaviour BufferedTask
 
-  @default_max_batch_size 10
-  @default_max_concurrency 4
+  @default_max_batch_size 1
+  @default_max_concurrency 1
+  @default_wait_time 1000
 
   @doc """
   Asynchronously fetches internal transactions.
@@ -93,6 +94,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
               tracer: Tracer
             )
   def run(block_numbers, json_rpc_named_arguments) do
+    :timer.sleep(Keyword.get(defaults(), :wait_time))
     unique_numbers =
       block_numbers
       |> Enum.uniq()
@@ -367,6 +369,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
       flush_interval: :timer.seconds(3),
       max_concurrency: Application.get_env(:indexer, __MODULE__)[:concurrency] || @default_max_concurrency,
       max_batch_size: Application.get_env(:indexer, __MODULE__)[:batch_size] || @default_max_batch_size,
+      wait_time: Application.get_env(:indexer, __MODULE__)[:wait_time] || @default_wait_time,
       task_supervisor: Indexer.Fetcher.InternalTransaction.TaskSupervisor,
       metadata: [fetcher: :internal_transaction]
     ]

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -652,8 +652,9 @@ config :indexer, Indexer.Fetcher.TokenInstance.Sanitize,
   concurrency: ConfigHelper.parse_integer_env_var("INDEXER_TOKEN_INSTANCE_SANITIZE_CONCURRENCY", 10)
 
 config :indexer, Indexer.Fetcher.InternalTransaction,
-  batch_size: ConfigHelper.parse_integer_env_var("INDEXER_INTERNAL_TRANSACTIONS_BATCH_SIZE", 10),
-  concurrency: ConfigHelper.parse_integer_env_var("INDEXER_INTERNAL_TRANSACTIONS_CONCURRENCY", 4),
+  batch_size: ConfigHelper.parse_integer_env_var("INDEXER_INTERNAL_TRANSACTIONS_BATCH_SIZE", 1),
+  concurrency: ConfigHelper.parse_integer_env_var("INDEXER_INTERNAL_TRANSACTIONS_CONCURRENCY", 1),
+  wait_time: ConfigHelper.parse_integer_env_var("INDEXER_INTERNAL_TRANSACTIONS_WAIT", 1000),
   indexing_finished_threshold:
     ConfigHelper.parse_integer_env_var("INDEXER_INTERNAL_TRANSACTIONS_INDEXING_FINISHED_THRESHOLD", 1000)
 


### PR DESCRIPTION
Changes:

-  Remove param in the rpc call that the EON node does not support
- Add a wait time to the fetch to ensure the node is not over-loaded, see https://horizenlabs.atlassian.net/browse/SDK-1411 

Along with the changes in this pr, the following ENV VARS should be set: 
```
INDEXER_INTERNAL_TRANSACTIONS_BATCH_SIZE=1
INDEXER_INTERNAL_TRANSACTIONS_CONCURRENCY=1
INDEXER_INTERNAL_TRANSACTIONS_WAIT=1000
ETHEREUM_JSONRPC_TRACE_URL=(env dependent but any public rpc will require basic auth)
```