### PR TITLE
fix: rm duplicate and erroneous config

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -277,10 +277,6 @@ tx_chart_config =
 config :block_scout_web,
   chart_config: Map.merge(price_chart_config, tx_chart_config)
 
-config :block_scout_web, BlockScoutWeb.Chain.Address.CoinBalance,
-  # days
-  coin_balance_history_days: System.get_env("COIN_BALANCE_HISTORY_DAYS", "10")
-
 config :block_scout_web, BlockScoutWeb.API.V2, enabled: System.get_env("API_V2_ENABLED") == "true"
 
 ########################


### PR DESCRIPTION
To resolve coin balance chart not loading
![Screenshot 2023-09-20 at 3 04 59 PM](https://github.com/HorizenLabs/eon-explorer/assets/14279989/0f19bf9c-7541-4919-a7a0-2690d45f0393)
