### PR TITLE
feat: index on to_address for ft and fp tables

### DIFF
--- a/apps/explorer/priv/repo/migrations/20230928192434_add_index_fee_payments_to_address_hash.exs
+++ b/apps/explorer/priv/repo/migrations/20230928192434_add_index_fee_payments_to_address_hash.exs
@@ -1,0 +1,16 @@
+defmodule Explorer.Repo.Migrations.AddIndexFeePaymentsToAddressHash do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+     create_if_not_exists(
+      index(
+        :fee_payments,
+        [:to_address_hash, "block_number DESC", "index DESC"],
+        name: "fee_payments_to_address_hash_index",
+        concurrently: true
+      )
+    )
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20230928193833_add_index_forward_transfers_to_address_hash.exs
+++ b/apps/explorer/priv/repo/migrations/20230928193833_add_index_forward_transfers_to_address_hash.exs
@@ -1,0 +1,16 @@
+defmodule Explorer.Repo.Migrations.AddIndexForwardTransfersToAddressHash do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+     create_if_not_exists(
+      index(
+        :forward_transfers,
+        [:to_address_hash, "block_number DESC", "index DESC"],
+        name: "forward_transfers_to_address_hash_index",
+        concurrently: true
+      )
+    )
+  end
+end


### PR DESCRIPTION
I was able to test on my local by dumping the pre-gobi explorer db and creating a copy on my local machine. Then I created the indexes and profiled the queries (before and after). Validated changes as well, no negative impacts, perhaps a slight increase in page load times.

Some good news about the migration scripts is that they will run concurrently with other db operations. That is, there will be no lock on the db and the explorer can still make reads and updates. I verified this on my local. See: https://fly.io/phoenix-files/migration-recipes/ for reference. 

Cost saving of index is about 30%
Here are the profiles for fee_payments query for an address with ~ 1000 rows before and after index: 
before index
[
  {
    "Plan": {
      "Node Type": "Limit",
      "Parallel Aware": false,
      "Async Capable": false,
      "Startup Cost": 0.29,
      "Total Cost": 50.58,
      "Plan Rows": 50,
      "Plan Width": 85,
      "Plans": [
        {
          "Node Type": "Index Scan",
          "Parent Relationship": "Outer",
          "Parallel Aware": false,
          "Async Capable": false,
          "Scan Direction": "Backward",
          "Index Name": "fee_payments_pkey",
          "Relation Name": "fee_payments",
          "Alias": "f0",
          "Startup Cost": 0.29,
          "Total Cost": 1037.27,
          "Plan Rows": 1031,
          "Plan Width": 85,
          "Filter": "(to_address_hash = '\\x7cb2471a407d95172679087a232e99c5fbd31e26'::bytea)"
        }
      ]
    }
  }
]
after index
[
  {
    "Plan": {
      "Node Type": "Limit",
      "Parallel Aware": false,
      "Async Capable": false,
      "Startup Cost": 0.29,
      "Total Cost": 34.60,
      "Plan Rows": 50,
      "Plan Width": 85,
      "Plans": [
        {
          "Node Type": "Index Scan",
          "Parent Relationship": "Outer",
          "Parallel Aware": false,
          "Async Capable": false,
          "Scan Direction": "Forward",
          "Index Name": "fee_payments_to_address_hash_index",
          "Relation Name": "fee_payments",
          "Alias": "f0",
          "Startup Cost": 0.29,
          "Total Cost": 707.77,
          "Plan Rows": 1031,
          "Plan Width": 85,
          "Index Cond": "(to_address_hash = '\\x7cb2471a407d95172679087a232e99c5fbd31e26'::bytea)"
        }
      ]
    }
  }
] 