### PR TITLE
TOOLS-2625 - add chackra-ui-color-mode cookie duration

### DIFF
--- a/apps/block_scout_web/assets/js/pages/dark-mode-switcher.js
+++ b/apps/block_scout_web/assets/js/pages/dark-mode-switcher.js
@@ -4,9 +4,9 @@ const darkModeChangerEl = document.getElementsByClassName('dark-mode-changer')[0
 
 darkModeChangerEl && darkModeChangerEl.addEventListener('click', function () {
   if (Cookies.get('chakra-ui-color-mode') === 'dark') {
-    Cookies.set('chakra-ui-color-mode', 'light')
+    Cookies.set('chakra-ui-color-mode', 'light', {expires: 30})
   } else {
-    Cookies.set('chakra-ui-color-mode', 'dark')
+    Cookies.set('chakra-ui-color-mode', 'dark', {expires: 30})
   }
   document.location.reload()
 })


### PR DESCRIPTION
In this PR:
- cookie `chackra-ui-color-mode` duration updated to several days and not to the duration of the session

Details in ticket [TOOLS-2625](https://horizenlabs.atlassian.net/browse/TOOLS-2625)