### PR TITLE
WEB3-97 - Fetch token price from Coingecko

### DIFF
--- a/apps/explorer/lib/explorer/exchange_rates/source.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source.ex
@@ -152,7 +152,7 @@ defmodule Explorer.ExchangeRates.Source do
         end
 
       _ ->
-        # if the response id not from the v3/simple/token_price/<platform> api return the input result unchanged
+        # if the response is not from the v3/simple/token_price/<platform> api return the input result unchanged
         result
 
     end

--- a/apps/explorer/lib/explorer/exchange_rates/source.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source.ex
@@ -6,6 +6,7 @@ defmodule Explorer.ExchangeRates.Source do
   alias Explorer.Chain.Hash
   alias Explorer.ExchangeRates.Source.CoinGecko
   alias Explorer.ExchangeRates.Token
+  alias Explorer.{ExchangeRates, Repo}
   alias HTTPoison.{Error, Response}
 
   @doc """
@@ -56,17 +57,63 @@ defmodule Explorer.ExchangeRates.Source do
     end
   end
 
+  defp remove_market_cap_if_certain_token(value, address) do
+    if address in ["0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab", "0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7"] do
+      Map.delete(value, "usd_market_cap")
+    else
+      value
+    end
+  end
+
+  defp swap_address(result, original_address, new_address) do
+    case Map.has_key?(result, original_address) do
+      true ->
+        {value, remaining_result} = Map.pop(result, original_address)
+        value_updated = remove_market_cap_if_certain_token(value, original_address)
+        Map.put(remaining_result, new_address, value_updated)
+
+      false ->
+        result
+    end
+  end
+
+  @spec get_exchange_rate(String.t()) :: Token.t() | nil
+  defp get_exchange_rate(symbol) do
+    ExchangeRates.lookup(symbol)
+  end
+
+  defp update_result_addresses(result) do
+
+    result
+    |> swap_address("0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab", "0x2c2E0B0c643aB9ad03adBe9140627A645E99E054") # weth
+    |> swap_address("0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7", "0x6318374DFb468113E06d3463ec5Ed0B6Ae0F0982") # wrapped-avax
+    |> swap_address("0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e", "0xCc44eB064CD32AAfEEb2ebb2a47bE0B882383b53") # usd-coin
+    |> swap_address("0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7", "0xA167bcAb6791304EDa9B636C8beEC75b3D2829E6") # tether
+    |> swap_address("0xd586e7f844cea2f87f50152665bcbc2c279d8d70", "0x38C2a6953F86a7453622B1E7103b738239728754") # dai
+    |> swap_address("0x5947bb275c521040051d82396192181b413227a3", "0xDF8DBA35962Aa0fAD7ade0Df07501c54Ec7c4A89") # chainlink
+    |> swap_address("0x50b7545627a5162f82a992c33b87adc75187b218", "0x1d7fb99AED3C365B4DEf061B7978CE5055Dfc1e7") # wrapped-bitcoin
+
+    zen_exchange_rate = get_exchange_rate("ZEN")
+    zen_usd_value = case zen_exchange_rate do %Explorer.ExchangeRates.Token{usd_value: uv} -> uv; _ -> nil end
+    zen_map = %{"0xF5cB8652a84329A2016A386206761f455bCEDab6" => %{"usd" => zen_usd_value}}
+    merged_result = Map.merge(result, zen_map)
+    merged_result
+
+  end
+
+
   defp fetch_exchange_rates_request(_source, source_url, _headers) when is_nil(source_url),
     do: {:error, "Source URL is nil"}
 
   defp fetch_exchange_rates_request(source, source_url, headers) do
     case http_request(source_url, headers) do
       {:ok, result} when is_map(result) ->
-        result_formatted =
-          result
-          |> source.format_data()
 
-        {:ok, result_formatted}
+        result_updated_and_formatted =
+        result
+        |> update_result_addresses()
+        |> source.format_data()
+        {:ok, result_updated_and_formatted}
 
       resp ->
         resp

--- a/apps/explorer/lib/explorer/exchange_rates/source/coin_gecko.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/coin_gecko.ex
@@ -68,11 +68,46 @@ defmodule Explorer.ExchangeRates.Source.CoinGecko do
     end)
   end
 
+  def add_token_address_for_platform(data, id, platform, value) do
+    Enum.map(data, fn entry ->
+      if entry["id"] == id do
+        %{
+          entry | "platforms" => Map.put(entry["platforms"], platform, value)
+        }
+      else
+        entry
+      end
+    end)
+  end
+
+  defp add_wrapped_zen(supported_coins) do
+    wrapped_zen = %{
+      "id" => "wrapped-zen",
+      "platforms" => %{
+        "horizen-eon" => "0xF5cB8652a84329A2016A386206761f455bCEDab6"
+      }
+    }
+    [wrapped_zen | supported_coins]
+  end
+
   @impl Source
   def format_data(supported_coins) when is_list(supported_coins) do
-    platform = platform()
 
-    supported_coins
+    #platform = platform()
+    platform = "horizen-eon"
+    supported_coins_updated = add_token_address_for_platform(supported_coins, "weth", "horizen-eon", "0x2c2E0B0c643aB9ad03adBe9140627A645E99E054")
+    supported_coins_updated = add_token_address_for_platform(supported_coins_updated, "wrapped-avax", "horizen-eon", "0x6318374DFb468113E06d3463ec5Ed0B6Ae0F0982")
+    supported_coins_updated = add_token_address_for_platform(supported_coins_updated, "usd-coin", "horizen-eon", "0xCc44eB064CD32AAfEEb2ebb2a47bE0B882383b53")
+    supported_coins_updated = add_token_address_for_platform(supported_coins_updated, "tether", "horizen-eon", "0xA167bcAb6791304EDa9B636C8beEC75b3D2829E6")
+    supported_coins_updated = add_token_address_for_platform(supported_coins_updated, "dai", "horizen-eon", "0x38C2a6953F86a7453622B1E7103b738239728754")
+    supported_coins_updated = add_token_address_for_platform(supported_coins_updated, "chainlink", "horizen-eon", "0xDF8DBA35962Aa0fAD7ade0Df07501c54Ec7c4A89")
+    supported_coins_updated = add_token_address_for_platform(supported_coins_updated, "wrapped-bitcoin", "horizen-eon", "0x1d7fb99AED3C365B4DEf061B7978CE5055Dfc1e7")
+
+
+    # Add the new entry for wrapped-zen
+    supported_coins_updated = add_wrapped_zen(supported_coins_updated)
+
+    supported_coins_updated
     |> Enum.reduce([], fn
       %{"platforms" => %{^platform => token_contract_hash_str}}, acc ->
         case Chain.Hash.Address.cast(token_contract_hash_str) do
@@ -115,9 +150,10 @@ defmodule Explorer.ExchangeRates.Source.CoinGecko do
 
   @impl Source
   def source_url(token_addresses) when is_list(token_addresses) do
-    joined_addresses = token_addresses |> Enum.map_join(",", &to_string/1)
+    platform = "avalanche"
+    joined_addresses = "0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab,0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7,0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e,0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7,0xd586e7f844cea2f87f50152665bcbc2c279d8d70,0x5947bb275c521040051d82396192181b413227a3,0x50b7545627a5162f82a992c33b87adc75187b218"
 
-    "#{base_url()}/simple/token_price/#{platform()}?vs_currencies=#{currency()}&include_market_cap=true&contract_addresses=#{joined_addresses}"
+    "#{base_url()}/simple/token_price/#{platform}?vs_currencies=#{currency()}&include_market_cap=true&contract_addresses=#{joined_addresses}"
   end
 
   @impl Source

--- a/apps/explorer/lib/explorer/exchange_rates/source/coin_gecko.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/coin_gecko.ex
@@ -90,19 +90,26 @@ defmodule Explorer.ExchangeRates.Source.CoinGecko do
     [wrapped_zen | supported_coins]
   end
 
+  @doc """
+  In the format_data method the wrapped token addresses will be added to the response of the coingecko api/v3/coins/list api (triggered by the token_exchange_rate module)
+  Moreover a new entry with id wrapped-zen is added since it is not present in the api response
+  These addresses will find match in the one currently present in the sidechain and they will put in the state variable tokens_to_fetch of the module token_exchange_rate
+  A tokens_to_fetch variable not empty will trigger a call to the coingecko v3/simple/token_price/<platform> to retrieve the wrapped token prices and market cap
+  """
   @impl Source
   def format_data(supported_coins) when is_list(supported_coins) do
 
     #platform = platform()
     platform = "horizen-eon"
-    supported_coins_updated = add_token_address_for_platform(supported_coins, "weth", "horizen-eon", "0x2c2E0B0c643aB9ad03adBe9140627A645E99E054")
-    supported_coins_updated = add_token_address_for_platform(supported_coins_updated, "wrapped-avax", "horizen-eon", "0x6318374DFb468113E06d3463ec5Ed0B6Ae0F0982")
-    supported_coins_updated = add_token_address_for_platform(supported_coins_updated, "usd-coin", "horizen-eon", "0xCc44eB064CD32AAfEEb2ebb2a47bE0B882383b53")
-    supported_coins_updated = add_token_address_for_platform(supported_coins_updated, "tether", "horizen-eon", "0xA167bcAb6791304EDa9B636C8beEC75b3D2829E6")
-    supported_coins_updated = add_token_address_for_platform(supported_coins_updated, "dai", "horizen-eon", "0x38C2a6953F86a7453622B1E7103b738239728754")
-    supported_coins_updated = add_token_address_for_platform(supported_coins_updated, "chainlink", "horizen-eon", "0xDF8DBA35962Aa0fAD7ade0Df07501c54Ec7c4A89")
-    supported_coins_updated = add_token_address_for_platform(supported_coins_updated, "wrapped-bitcoin", "horizen-eon", "0x1d7fb99AED3C365B4DEf061B7978CE5055Dfc1e7")
-
+    supported_coins_updated =
+      supported_coins
+      |> add_token_address_for_platform("weth", "horizen-eon", "0x2c2E0B0c643aB9ad03adBe9140627A645E99E054")
+      |> add_token_address_for_platform("wrapped-avax", "horizen-eon", "0x6318374DFb468113E06d3463ec5Ed0B6Ae0F0982")
+      |> add_token_address_for_platform("usd-coin", "horizen-eon", "0xCc44eB064CD32AAfEEb2ebb2a47bE0B882383b53")
+      |> add_token_address_for_platform("tether", "horizen-eon", "0xA167bcAb6791304EDa9B636C8beEC75b3D2829E6")
+      |> add_token_address_for_platform("dai", "horizen-eon", "0x38C2a6953F86a7453622B1E7103b738239728754")
+      |> add_token_address_for_platform("chainlink", "horizen-eon", "0xDF8DBA35962Aa0fAD7ade0Df07501c54Ec7c4A89")
+      |> add_token_address_for_platform("wrapped-bitcoin", "horizen-eon", "0x1d7fb99AED3C365B4DEf061B7978CE5055Dfc1e7")
 
     # Add the new entry for wrapped-zen
     supported_coins_updated = add_wrapped_zen(supported_coins_updated)
@@ -148,6 +155,10 @@ defmodule Explorer.ExchangeRates.Source.CoinGecko do
     "#{base_url()}/coins/list?include_platform=true"
   end
 
+  @doc """
+  The v3/simple/token_price/<platform> will be performed to the avalanche platform because it has all the wrapped tokens data required in the horizen-eon sidechain,
+  so the mothod sets the platform as avalanche for this call and passes all the avalanche wrapped token addresses present on the c-chain
+  """
   @impl Source
   def source_url(token_addresses) when is_list(token_addresses) do
     platform = "avalanche"

--- a/apps/explorer/lib/explorer/exchange_rates/source/coin_market_cap.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/coin_market_cap.ex
@@ -98,21 +98,22 @@ defmodule Explorer.ExchangeRates.Source.CoinMarketCap do
     config(:coin_id)
   end
 
-  defp get_token_properties(market_data) do
-    token_values_list =
-      market_data
-      |> Map.values()
-
-    if Enum.count(token_values_list) > 0 do
-      token_values = token_values_list |> Enum.at(0)
-
-      if Enum.count(token_values) > 0 do
+  @doc """
+  Extracts token properties from CoinMarketCap coin endpoint response
+  """
+  @spec get_token_properties(map()) :: map()
+  def get_token_properties(market_data) do
+    with token_values_list <- market_data |> Map.values(),
+         true <- Enum.count(token_values_list) > 0,
+         token_values <- token_values_list |> Enum.at(0),
+         true <- Enum.count(token_values) > 0 do
+      if is_list(token_values) do
         token_values |> Enum.at(0)
       else
-        %{}
+        token_values
       end
     else
-      %{}
+      _ -> %{}
     end
   end
 


### PR DESCRIPTION
In this PR the logic to fetch the token price from Coingecko.
Right now the horizen-eon platform is not defined on Coingecko so the logic introduced with this PR will manage the token price fetch until the horizen sidechain is added.