### PR TITLE
WEB3-357 - Token market cap value fix

### DIFF
--- a/apps/explorer/lib/explorer/exchange_rates/source.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source.ex
@@ -109,6 +109,7 @@ defmodule Explorer.ExchangeRates.Source do
 
   # --------------------------------------------------------------------------------
   # add the wrapped-zen map with the exchange rate read from the database
+  # convert it to float (with 2 decimal places) before put it in the map
   @wrapped_zen_env_var "WRAPPED_ZEN_ADDRESS"
   defp create_wrapped_zen_map do
     zen_exchange_rate = get_exchange_rate(Explorer.coin())
@@ -117,8 +118,8 @@ defmodule Explorer.ExchangeRates.Source do
         %Explorer.ExchangeRates.Token{usd_value: uv} -> uv
         _ -> nil
       end
-
-    %{System.get_env(@wrapped_zen_env_var) => %{"usd" => zen_usd_value}}
+    zen_usd_value_float = Float.round(Decimal.to_float(zen_usd_value), 2)
+    %{System.get_env(@wrapped_zen_env_var) => %{"usd" => zen_usd_value_float}}
   end
 
   # --------------------------------------------------------------------------------

--- a/apps/explorer/lib/explorer/exchange_rates/token_exchange_rates.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/token_exchange_rates.ex
@@ -99,12 +99,30 @@ defmodule Explorer.ExchangeRates.TokenExchangeRates do
   defp update_token(%{contract_address_hash: contract_address_hash} = token, token_to_market_data) do
     case Map.get(token_to_market_data, contract_address_hash) do
       %{} = market_data ->
+
+        # update the circulating market cap of the token retrieving:
+        # - the total supply from the token
+        # - the exchange rate from the coingecko response
+        tokens = divide_decimals(token.total_supply, token.decimals)
+        tokens_float = Float.round(Decimal.to_float(tokens), 2)
+        market_cap_float = market_data.fiat_value * tokens_float
+        updated_market_data =
+          %{market_data | circulating_market_cap: market_cap_float}
+
         token
-        |> Token.changeset(market_data)
+        |> Token.changeset(updated_market_data)
         |> Repo.update(returning: false)
 
       _ ->
         nil
     end
   end
+
+  @spec divide_decimals(Decimal.t(), Decimal.t()) :: Decimal.t()
+  def divide_decimals(%{sign: sign, coef: coef, exp: exp}, decimals) do
+    sign
+    |> Decimal.new(coef, exp - Decimal.to_integer(decimals))
+    |> Decimal.normalize()
+  end
+
 end


### PR DESCRIPTION
In this pull request:
- token market cap value fix to show only the market cap related to the value present on the EON sidechain and not the entire crypto space.

The market cap value related to the value present on EON sidechain is calculated using the fiat value retrieved by coingecko and then saved on the database. The tokens are displayed ordered by market cap on the tokens page.
I wanted to avoid changes on the current blockscout UI so this logic can be compatible with the next React UI.

![image](https://github.com/HorizenLabs/eon-explorer/assets/93270762/f7c864fa-ce29-4691-84d9-9b9cbb7e866c)
