### PR TITLE
Native contracts script fix for blue/green deployment support

### DIFF
--- a/apps/explorer/priv/repo/migrations/20240209100816_withdrawal_request_native_contract_data.exs
+++ b/apps/explorer/priv/repo/migrations/20240209100816_withdrawal_request_native_contract_data.exs
@@ -39,30 +39,53 @@ defmodule Explorer.Repo.Migrations.WithdrawalRequestNativeContractData do
        END $$"
     )
 
-    execute("
-    INSERT INTO smart_contracts (
-      name,
-      compiler_version,
-      optimization,
-      contract_source_code,
-      abi,
-      address_hash,
-      inserted_at,
-      updated_at,
-      contract_code_md5)
-     VALUES (
-      'Withdrawal Request',
-      '-',
-      false,
-      '/',
-      '[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes20\",\"name\":\"mcDest\",\"type\":\"bytes20\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"epochNumber\",\"type\":\"uint32\"}],\"name\":\"AddWithdrawalRequest\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"PubKeyHash\",\"name\":\"pubKeyHash\",\"type\":\"bytes20\"}],\"name\":\"backwardTransfer\",\"outputs\":[{\"components\":[{\"internalType\":\"PubKeyHash\",\"name\":\"pubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"internalType\":\"struct WithdrawalRequests.WithdrawalRequest\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"withdrawalEpoch\",\"type\":\"uint32\"}],\"name\":\"getBackwardTransfers\",\"outputs\":[{\"components\":[{\"internalType\":\"PubKeyHash\",\"name\":\"pubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"internalType\":\"struct WithdrawalRequests.WithdrawalRequest[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]',
-      E'\\\\x0000000000000000000011111111111111111111',
-      NOW(),
-      NOW(),
-      '6666cd76f96956469e7be39d750cc7d9'
-     );")
+    execute(
+      "DO $$
+       BEGIN
 
-    execute("INSERT INTO address_names(address_hash, name, \"primary\", inserted_at, updated_at) VALUES (E'\\\\x0000000000000000000011111111111111111111', 'Withdrawal Request', true, NOW(), NOW())")
+         -- Check if the record with the specified hash exists
+         IF NOT EXISTS (SELECT 1 FROM smart_contracts WHERE address_hash = E'\\\\x0000000000000000000011111111111111111111') THEN
+
+           -- Insert a new record if it doesn't exist
+           INSERT INTO smart_contracts (
+              name,
+              compiler_version,
+              optimization,
+              contract_source_code,
+              abi,
+              address_hash,
+              inserted_at,
+              updated_at,
+              contract_code_md5)
+            VALUES (
+              'Withdrawal Request',
+              '-',
+              false,
+              '/',
+              '[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes20\",\"name\":\"mcDest\",\"type\":\"bytes20\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"epochNumber\",\"type\":\"uint32\"}],\"name\":\"AddWithdrawalRequest\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"PubKeyHash\",\"name\":\"pubKeyHash\",\"type\":\"bytes20\"}],\"name\":\"backwardTransfer\",\"outputs\":[{\"components\":[{\"internalType\":\"PubKeyHash\",\"name\":\"pubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"internalType\":\"struct WithdrawalRequests.WithdrawalRequest\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"withdrawalEpoch\",\"type\":\"uint32\"}],\"name\":\"getBackwardTransfers\",\"outputs\":[{\"components\":[{\"internalType\":\"PubKeyHash\",\"name\":\"pubKeyHash\",\"type\":\"bytes20\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"internalType\":\"struct WithdrawalRequests.WithdrawalRequest[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]',
+              E'\\\\x0000000000000000000011111111111111111111',
+              NOW(),
+              NOW(),
+              '6666cd76f96956469e7be39d750cc7d9'
+            );
+
+         END IF;
+       END $$"
+    )
+
+    execute(
+      "DO $$
+       BEGIN
+
+         -- Check if the record with the specified hash exists
+         IF NOT EXISTS (SELECT 1 FROM address_names WHERE address_hash = E'\\\\x0000000000000000000011111111111111111111') THEN
+
+          INSERT INTO address_names(address_hash, name, \"primary\", inserted_at, updated_at) VALUES (E'\\\\x0000000000000000000011111111111111111111', 'Withdrawal Request', true, NOW(), NOW());
+
+         END IF;
+       END $$"
+    )
+
     execute("INSERT INTO reserved_addresses(address_hash, name, is_contract, inserted_at) VALUES (E'\\\\x0000000000000000000011111111111111111111', 'withdrawal request', true, NOW())")
 
   end

--- a/apps/explorer/priv/repo/migrations/20240209101418_forger_stake_native_contract_data.exs
+++ b/apps/explorer/priv/repo/migrations/20240209101418_forger_stake_native_contract_data.exs
@@ -39,30 +39,52 @@ defmodule Explorer.Repo.Migrations.ForgerStakeNativeContractData do
        END $$"
     )
 
-    execute("
-      INSERT INTO smart_contracts (
-            name,
-            compiler_version,
-            optimization,
-            contract_source_code,
-            abi,
-            address_hash,
-            inserted_at,
-            updated_at,
-            contract_code_md5)
-          VALUES (
-            'Forger Stake',
-            '-',
-            false,
-            '/',
-            '[{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"publicKey\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"vrf1\",\"type\":\"bytes32\"},{\"internalType\":\"bytes1\",\"name\":\"vrf2\",\"type\":\"bytes1\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"delegate\",\"outputs\":[{\"internalType\":\"StakeID\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getAllForgersStakes\",\"outputs\":[{\"components\":[{\"internalType\":\"StakeID\",\"name\":\"stakeId\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"stakedAmount\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"publicKey\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"vrf1\",\"type\":\"bytes32\"},{\"internalType\":\"bytes1\",\"name\":\"vrf2\",\"type\":\"bytes1\"}],\"internalType\":\"struct ForgerStakes.StakeInfo[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"forgerIndex\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"signature1\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"signature2\",\"type\":\"bytes32\"}],\"name\":\"openStakeForgerList\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"StakeID\",\"name\":\"stakeId\",\"type\":\"bytes32\"},{\"internalType\":\"bytes1\",\"name\":\"signatureV\",\"type\":\"bytes1\"},{\"internalType\":\"bytes32\",\"name\":\"signatureR\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"signatureS\",\"type\":\"bytes32\"}],\"name\":\"withdraw\",\"outputs\":[{\"internalType\":\"StakeID\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]',
-            E'\\\\x0000000000000000000022222222222222222222',
-            NOW(),
-            NOW(),
-            '6666cd76f96956469e7be39d750cc7d9'
-          );")
+    execute(
+      "DO $$
+       BEGIN
 
-    execute("INSERT INTO address_names(address_hash, name, \"primary\", inserted_at, updated_at) VALUES (E'\\\\x0000000000000000000022222222222222222222', 'Forger Stake', true, NOW(), NOW())")
+         -- Check if the record with the specified hash exists
+         IF NOT EXISTS (SELECT 1 FROM smart_contracts WHERE address_hash = E'\\\\x0000000000000000000022222222222222222222') THEN
+
+          INSERT INTO smart_contracts (
+              name,
+              compiler_version,
+              optimization,
+              contract_source_code,
+              abi,
+              address_hash,
+              inserted_at,
+              updated_at,
+              contract_code_md5)
+            VALUES (
+              'Forger Stake',
+              '-',
+              false,
+              '/',
+              '[{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"publicKey\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"vrf1\",\"type\":\"bytes32\"},{\"internalType\":\"bytes1\",\"name\":\"vrf2\",\"type\":\"bytes1\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"delegate\",\"outputs\":[{\"internalType\":\"StakeID\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getAllForgersStakes\",\"outputs\":[{\"components\":[{\"internalType\":\"StakeID\",\"name\":\"stakeId\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"stakedAmount\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"publicKey\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"vrf1\",\"type\":\"bytes32\"},{\"internalType\":\"bytes1\",\"name\":\"vrf2\",\"type\":\"bytes1\"}],\"internalType\":\"struct ForgerStakes.StakeInfo[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"forgerIndex\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"signature1\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"signature2\",\"type\":\"bytes32\"}],\"name\":\"openStakeForgerList\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"StakeID\",\"name\":\"stakeId\",\"type\":\"bytes32\"},{\"internalType\":\"bytes1\",\"name\":\"signatureV\",\"type\":\"bytes1\"},{\"internalType\":\"bytes32\",\"name\":\"signatureR\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"signatureS\",\"type\":\"bytes32\"}],\"name\":\"withdraw\",\"outputs\":[{\"internalType\":\"StakeID\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]',
+              E'\\\\x0000000000000000000022222222222222222222',
+              NOW(),
+              NOW(),
+              '6666cd76f96956469e7be39d750cc7d9'
+            );
+
+         END IF;
+       END $$"
+    )
+
+    execute(
+      "DO $$
+       BEGIN
+
+         -- Check if the record with the specified hash exists
+         IF NOT EXISTS (SELECT 1 FROM address_names WHERE address_hash = E'\\\\x0000000000000000000022222222222222222222') THEN
+
+          INSERT INTO address_names(address_hash, name, \"primary\", inserted_at, updated_at) VALUES (E'\\\\x0000000000000000000022222222222222222222', 'Forger Stake', true, NOW(), NOW());
+
+         END IF;
+       END $$"
+    )
+
     execute("INSERT INTO reserved_addresses(address_hash, name, is_contract, inserted_at) VALUES (E'\\\\x0000000000000000000022222222222222222222', 'forger stake', true, NOW())")
 
   end

--- a/apps/explorer/priv/repo/migrations/20240209101840_certificate_key_rotation_native_contract_data.exs
+++ b/apps/explorer/priv/repo/migrations/20240209101840_certificate_key_rotation_native_contract_data.exs
@@ -38,30 +38,52 @@ defmodule Explorer.Repo.Migrations.CertificateKeyRotationNativeContractData do
        END $$"
     )
 
-    execute("
-      INSERT INTO smart_contracts (
-        name,
-        compiler_version,
-        optimization,
-        contract_source_code,
-        abi,
-        address_hash,
-        inserted_at,
-        updated_at,
-        contract_code_md5)
-      VALUES (
-        'Certificate Key Rotation',
-        '-',
-        false,
-        '/',
-        '[{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"key_type\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"index\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"newKey_1\",\"type\":\"bytes32\"},{\"internalType\":\"bytes1\",\"name\":\"newKey_2\",\"type\":\"bytes1\"},{\"internalType\":\"bytes32\",\"name\":\"signKeySig_1\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"signKeySig_2\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"masterKeySig_1\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"masterKeySig_2\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"newKeySig_1\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"newKeySig_2\",\"type\":\"bytes32\"}],\"name\":\"submitKeyRotation\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"bytes1\",\"name\":\"\",\"type\":\"bytes1\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]',
-        E'\\\\x0000000000000000000044444444444444444444',
-        NOW(),
-        NOW(),
-        '6666cd76f96956469e7be39d750cc7d9'
-      );")
+    execute(
+      "DO $$
+        BEGIN
 
-    execute("INSERT INTO address_names(address_hash, name, \"primary\", inserted_at, updated_at) VALUES (E'\\\\x0000000000000000000044444444444444444444', 'Certificate Key Rotation', true, NOW(), NOW())")
+          -- Check if the record with the specified hash exists
+          IF NOT EXISTS (SELECT 1 FROM smart_contracts WHERE address_hash = E'\\\\x0000000000000000000044444444444444444444') THEN
+
+            INSERT INTO smart_contracts (
+              name,
+              compiler_version,
+              optimization,
+              contract_source_code,
+              abi,
+              address_hash,
+              inserted_at,
+              updated_at,
+              contract_code_md5)
+            VALUES (
+              'Certificate Key Rotation',
+              '-',
+              false,
+              '/',
+              '[{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"key_type\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"index\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"newKey_1\",\"type\":\"bytes32\"},{\"internalType\":\"bytes1\",\"name\":\"newKey_2\",\"type\":\"bytes1\"},{\"internalType\":\"bytes32\",\"name\":\"signKeySig_1\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"signKeySig_2\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"masterKeySig_1\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"masterKeySig_2\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"newKeySig_1\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"newKeySig_2\",\"type\":\"bytes32\"}],\"name\":\"submitKeyRotation\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"bytes1\",\"name\":\"\",\"type\":\"bytes1\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]',
+              E'\\\\x0000000000000000000044444444444444444444',
+              NOW(),
+              NOW(),
+              '6666cd76f96956469e7be39d750cc7d9'
+            );
+
+          END IF;
+        END $$"
+    )
+
+    execute(
+      "DO $$
+        BEGIN
+
+          -- Check if the record with the specified hash exists
+          IF NOT EXISTS (SELECT 1 FROM address_names WHERE address_hash = E'\\\\x0000000000000000000044444444444444444444') THEN
+
+          INSERT INTO address_names(address_hash, name, \"primary\", inserted_at, updated_at) VALUES (E'\\\\x0000000000000000000044444444444444444444', 'Certificate Key Rotation', true, NOW(), NOW());
+
+          END IF;
+        END $$"
+    )
+
     execute("INSERT INTO reserved_addresses(address_hash, name, is_contract, inserted_at) VALUES (E'\\\\x0000000000000000000044444444444444444444', 'certificate key rotation', true, NOW())")
 
   end

--- a/apps/explorer/priv/repo/migrations/20240209102106_mainchain_address_ownership_native_contract_data.exs
+++ b/apps/explorer/priv/repo/migrations/20240209102106_mainchain_address_ownership_native_contract_data.exs
@@ -38,30 +38,52 @@ defmodule Explorer.Repo.Migrations.MainchainAddressOwnershipNativeContractData d
        END $$"
     )
 
-    execute("
-      INSERT INTO smart_contracts (
-        name,
-        compiler_version,
-        optimization,
-        contract_source_code,
-        abi,
-        address_hash,
-        inserted_at,
-        updated_at,
-        contract_code_md5)
-      VALUES (
-        'Mainchain Address Ownership',
-        '-',
-        false,
-        '/',
-        '[{\"inputs\":[],\"name\":\"getAllKeyOwnerships\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"scAddress\",\"type\":\"address\"},{\"internalType\":\"bytes3\",\"name\":\"mcAddrBytes1\",\"type\":\"bytes3\"},{\"internalType\":\"bytes32\",\"name\":\"mcAddrBytes2\",\"type\":\"bytes32\"}],\"internalType\":\"struct McAddrOwnership.McAddrOwnershipData[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getKeyOwnerScAddresses\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"scAddress\",\"type\":\"address\"}],\"name\":\"getKeyOwnerships\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"scAddress\",\"type\":\"address\"},{\"internalType\":\"bytes3\",\"name\":\"mcAddrBytes1\",\"type\":\"bytes3\"},{\"internalType\":\"bytes32\",\"name\":\"mcAddrBytes2\",\"type\":\"bytes32\"}],\"internalType\":\"struct McAddrOwnership.McAddrOwnershipData[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes3\",\"name\":\"mcAddrBytes1\",\"type\":\"bytes3\"},{\"internalType\":\"bytes32\",\"name\":\"mcAddrBytes2\",\"type\":\"bytes32\"}],\"name\":\"removeKeysOwnership\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes3\",\"name\":\"mcAddrBytes1\",\"type\":\"bytes3\"},{\"internalType\":\"bytes32\",\"name\":\"mcAddrBytes2\",\"type\":\"bytes32\"},{\"internalType\":\"bytes24\",\"name\":\"signature1\",\"type\":\"bytes24\"},{\"internalType\":\"bytes32\",\"name\":\"signature2\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"signature3\",\"type\":\"bytes32\"}],\"name\":\"sendKeysOwnership\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"mcMultisigAddress\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"redeemScript\",\"type\":\"string\"},{\"internalType\":\"string[]\",\"name\":\"mcSignatures\",\"type\":\"string[]\"}],\"name\":\"sendMultisigKeysOwnership\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]',
-        E'\\\\x0000000000000000000088888888888888888888',
-        NOW(),
-        NOW(),
-        '6666cd76f96956469e7be39d750cc7d9'
-      );")
+    execute(
+      "DO $$
+        BEGIN
 
-    execute("INSERT INTO address_names(address_hash, name, \"primary\", inserted_at, updated_at) VALUES (E'\\\\x0000000000000000000088888888888888888888', 'Mainchain Address Ownership', true, NOW(), NOW())")
+          -- Check if the record with the specified hash exists
+          IF NOT EXISTS (SELECT 1 FROM smart_contracts WHERE address_hash = E'\\\\x0000000000000000000088888888888888888888') THEN
+
+            INSERT INTO smart_contracts (
+              name,
+              compiler_version,
+              optimization,
+              contract_source_code,
+              abi,
+              address_hash,
+              inserted_at,
+              updated_at,
+              contract_code_md5)
+            VALUES (
+              'Mainchain Address Ownership',
+              '-',
+              false,
+              '/',
+              '[{\"inputs\":[],\"name\":\"getAllKeyOwnerships\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"scAddress\",\"type\":\"address\"},{\"internalType\":\"bytes3\",\"name\":\"mcAddrBytes1\",\"type\":\"bytes3\"},{\"internalType\":\"bytes32\",\"name\":\"mcAddrBytes2\",\"type\":\"bytes32\"}],\"internalType\":\"struct McAddrOwnership.McAddrOwnershipData[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getKeyOwnerScAddresses\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"scAddress\",\"type\":\"address\"}],\"name\":\"getKeyOwnerships\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"scAddress\",\"type\":\"address\"},{\"internalType\":\"bytes3\",\"name\":\"mcAddrBytes1\",\"type\":\"bytes3\"},{\"internalType\":\"bytes32\",\"name\":\"mcAddrBytes2\",\"type\":\"bytes32\"}],\"internalType\":\"struct McAddrOwnership.McAddrOwnershipData[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes3\",\"name\":\"mcAddrBytes1\",\"type\":\"bytes3\"},{\"internalType\":\"bytes32\",\"name\":\"mcAddrBytes2\",\"type\":\"bytes32\"}],\"name\":\"removeKeysOwnership\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes3\",\"name\":\"mcAddrBytes1\",\"type\":\"bytes3\"},{\"internalType\":\"bytes32\",\"name\":\"mcAddrBytes2\",\"type\":\"bytes32\"},{\"internalType\":\"bytes24\",\"name\":\"signature1\",\"type\":\"bytes24\"},{\"internalType\":\"bytes32\",\"name\":\"signature2\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"signature3\",\"type\":\"bytes32\"}],\"name\":\"sendKeysOwnership\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"mcMultisigAddress\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"redeemScript\",\"type\":\"string\"},{\"internalType\":\"string[]\",\"name\":\"mcSignatures\",\"type\":\"string[]\"}],\"name\":\"sendMultisigKeysOwnership\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]',
+              E'\\\\x0000000000000000000088888888888888888888',
+              NOW(),
+              NOW(),
+              '6666cd76f96956469e7be39d750cc7d9'
+            );
+
+          END IF;
+        END $$"
+    )
+
+    execute(
+      "DO $$
+        BEGIN
+
+          -- Check if the record with the specified hash exists
+          IF NOT EXISTS (SELECT 1 FROM address_names WHERE address_hash = E'\\\\x0000000000000000000088888888888888888888') THEN
+
+            INSERT INTO address_names(address_hash, name, \"primary\", inserted_at, updated_at) VALUES (E'\\\\x0000000000000000000088888888888888888888', 'Mainchain Address Ownership', true, NOW(), NOW());
+
+          END IF;
+        END $$"
+    )
+
     execute("INSERT INTO reserved_addresses(address_hash, name, is_contract, inserted_at) VALUES (E'\\\\x0000000000000000000088888888888888888888', 'mainchain address ownership', true, NOW())")
 
   end


### PR DESCRIPTION
In this pull request script fix for blue/green deployment support.
The current script will fail if used with the current blue/green deployment process and with already present data in the tables with off-chain data (`smart_contracts` and` address_names` tables), this because the current deployment process migrate the content of these tables before running the blockscout scripts.
The fix add some conditions to insert data in `smart_contracts` and `address_names` only if not already present.