### PR TITLE
Invert read methods order for native contracts

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
@@ -36,7 +36,7 @@
                 ) %></h3>
 </div>
 <% end %>
-<%= for {function, counter} <- Enum.with_index(if smart_contract_native, do: @read_functions_required_wallet ++ @read_only_functions, else: @read_only_functions ++ @read_functions_required_wallet) do %>
+<%= for {function, counter} <- Enum.with_index((if smart_contract_native, do: @read_functions_required_wallet ++ @read_only_functions, else: @read_only_functions ++ @read_functions_required_wallet),1) do %>
   <div class="d-flex py-2 border-bottom" data-function<%= if assigns[:custom_abi], do: "-custom" %>>
     <div class="py-2 pr-2 text-nowrap">
       <%= counter %>.

--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
@@ -36,7 +36,7 @@
                 ) %></h3>
 </div>
 <% end %>
-<%= for {function, counter} <- Enum.with_index(@read_only_functions ++ @read_functions_required_wallet, 1) do %>
+<%= for {function, counter} <- Enum.with_index(if smart_contract_native, do: @read_functions_required_wallet ++ @read_only_functions, else: @read_only_functions ++ @read_functions_required_wallet) do %>
   <div class="d-flex py-2 border-bottom" data-function<%= if assigns[:custom_abi], do: "-custom" %>>
     <div class="py-2 pr-2 text-nowrap">
       <%= counter %>.


### PR DESCRIPTION
To increase readability of the native contract read methods (because their response can be very big) this PR invert the order of the methods showing first the reading methods that require interaction with a wallet and after the only read methods.
This is a tradeoff because the solution can be give the user the possibility to call the read methods without inputs without it being automatic.
This feature relates only to native contracts and not to solidity contracts.