### PR TITLE
WEB3-522 - Escape ampersand character in query params string

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api_docs_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api_docs_view.ex
@@ -31,7 +31,7 @@ defmodule BlockScoutWeb.APIDocsView do
 
   defp required_params(action) do
     Enum.map(action.required_params, fn param ->
-      "&#{param.key}=" <> "{<strong>#{param.placeholder}</strong>}"
+      "&amp;#{param.key}=" <> "{<strong>#{param.placeholder}</strong>}"
     end)
   end
 


### PR DESCRIPTION
On the api-docs page the parameters are displayed for each method divided by the ampersand character.
For the `getblocknobytime` method to get block number by timestamp the combination between the ampersand character and the timestamp parameter led to an incorrectly string displayed: `×tamp={blockTimestamp}` instead of `timestamp={blockTimestamp}`
This because the combination `&times` are parsed as `×` (multiplication) in the html page.
To correct this ampersand character is now escaped in the `api_docs_view.required_params` method.

The parameters for `getblocknobytime` are now `?module=block&action=getblocknobytime&timestamp={blockTimestamp}&closest={before/after} ` as required in the WEB3-522 ticket.
The other path in the api-docs page are not changed.