### PR TITLE
WEB3-502 - Remove non-payable methods in read section for native contracts

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
@@ -36,7 +36,7 @@
                 ) %></h3>
 </div>
 <% end %>
-<%= for {function, counter} <- Enum.with_index((if smart_contract_native, do: @read_only_functions, else: @read_only_functions ++ @read_functions_required_wallet),1) do %>
+<%= for {function, counter} <- Enum.with_index(@read_only_functions, 1) do %>
   <div class="d-flex py-2 border-bottom" data-function<%= if assigns[:custom_abi], do: "-custom" %>>
     <div class="py-2 pr-2 text-nowrap">
       <%= counter %>.

--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
@@ -36,7 +36,7 @@
                 ) %></h3>
 </div>
 <% end %>
-<%= for {function, counter} <- Enum.with_index((if smart_contract_native, do: @read_functions_required_wallet ++ @read_only_functions, else: @read_only_functions ++ @read_functions_required_wallet),1) do %>
+<%= for {function, counter} <- Enum.with_index((if smart_contract_native, do: @read_only_functions, else: @read_only_functions ++ @read_functions_required_wallet),1) do %>
   <div class="d-flex py-2 border-bottom" data-function<%= if assigns[:custom_abi], do: "-custom" %>>
     <div class="py-2 pr-2 text-nowrap">
       <%= counter %>.

--- a/apps/explorer/lib/explorer/smart_contract/helper.ex
+++ b/apps/explorer/lib/explorer/smart_contract/helper.ex
@@ -22,7 +22,7 @@ defmodule Explorer.SmartContract.Helper do
   @spec read_with_wallet_method?(%{}) :: true | false
   def read_with_wallet_method?(function),
     do:
-      !error?(function) && !event?(function) && !constructor?(function) && nonpayable?(function) &&
+      !error?(function) && !event?(function) && !constructor?(function) &&
         !empty_outputs?(function)
 
   def empty_outputs?(function), do: is_nil(function["outputs"]) || function["outputs"] == []

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule BlockScout.Mixfile do
     [
       # app: :block_scout,
       # aliases: aliases(config_env()),
-      version: "3.3.1",
+      version: "3.3.0-RC1",
       apps_path: "apps",
       deps: deps(),
       dialyzer: dialyzer(),


### PR DESCRIPTION
With this PR only the `view` methods of the native contracts are displayed in the _read_ section, meanwhile the `nonpayable` and `payable` methods are displayed in the _write_ section.
The situation remain unaltered for the other solidity contracts.

This the list for all the native contracts

**Withdrawal_Request - 0x0000000000000000000011111111111111111111**
_read section_:
- getBackwardTransfers - view

_write section_:
- backwardTransfer - payable


**Forger_Stake - 0x0000000000000000000022222222222222222222**
_read section_:

- getAllForgersStakes - view

_write section_:

- openStakeForgerList - nonpayable
- withdraw - nonpayable
- delegate - payable

**Certificate_Key_Rotation - 0x0000000000000000000044444444444444444444**
_read section_:

- /

_write section_:

- submitKeyRotation - nonpayable


**Mainchain_Address_Ownership (ZEN-DAO) - 0x0000000000000000000088888888888888888888**
_read section_:

- getAllKeyOwnerships - view
- getKeyOwnerScAddresses  - view
- getKeyOwnership - view

_write section_:
- removeKeysOwnership - nonpayable
- sendKeysOwnership - nonpayable
- sendMultisigKeysOwnership - nonpayable

