### PR TITLE
WEB3-521

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/block_controller.ex
@@ -5,13 +5,18 @@ defmodule BlockScoutWeb.API.RPC.BlockController do
   alias Explorer.Chain
   alias Explorer.Chain.Cache.BlockNumber
 
+  require Logger
+
   def getblockreward(conn, params) do
     with {:block_param, {:ok, unsafe_block_number}} <- {:block_param, Map.fetch(params, "blockno")},
          {:ok, block_number} <- ChainWeb.param_to_block_number(unsafe_block_number),
          {:ok, block} <- Chain.number_to_block(block_number) do
-      reward = Chain.block_reward(block_number)
-
-      render(conn, :block_reward, block: block, reward: reward)
+      case Chain.block_reward(block_number) do
+        nil ->
+          render(conn, :error, error: "No block reward data related to this block")
+        reward ->
+          render(conn, :block_reward, block: block, reward: reward)
+      end
     else
       {:block_param, :error} ->
         render(conn, :error, error: "Query parameter 'blockno' is required")

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/block_controller.ex
@@ -5,8 +5,6 @@ defmodule BlockScoutWeb.API.RPC.BlockController do
   alias Explorer.Chain
   alias Explorer.Chain.Cache.BlockNumber
 
-  require Logger
-
   def getblockreward(conn, params) do
     with {:block_param, {:ok, unsafe_block_number}} <- {:block_param, Map.fetch(params, "blockno")},
          {:ok, block_number} <- ChainWeb.param_to_block_number(unsafe_block_number),

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/block_controller_test.exs
@@ -4,8 +4,6 @@ defmodule BlockScoutWeb.API.RPC.BlockControllerTest do
   alias Explorer.Chain.{Hash, Wei}
   alias BlockScoutWeb.Chain
 
-  require Logger
-
   describe "getblockreward" do
     test "with missing block number", %{conn: conn} do
       response =


### PR DESCRIPTION
Previously empty responses for called to _api_ endpoint with `module=block` and `action=getblockreward` were not managed and the response was this:
```
{
    "message": "Something went wrong.",
    "result": null,
    "status": "0"
}
```
with this PR the response will be:
```
{
    "message": "No block reward data related to this block",
    "result": null,
    "status": "0"
}
```

However the `block_rewards` table of the sidechain database, from which the block reward data is read, doesn't have any record. This will require an additional investigation.