### PR TITLE
WEB3-260 - WEB3-261

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -169,6 +169,7 @@ defmodule BlockScoutWeb.ApiRouter do
       get("/:block_hash_or_number", V2.BlockController, :block)
       get("/:block_hash_or_number/transactions", V2.BlockController, :transactions)
       get("/:block_hash_or_number/withdrawals", V2.BlockController, :withdrawals)
+      get("/:block_hash_or_number/forward-transfers", V2.BlockController, :forward_transfers)
     end
 
     scope "/addresses" do
@@ -185,6 +186,11 @@ defmodule BlockScoutWeb.ApiRouter do
       get("/:address_hash/coin-balance-history", V2.AddressController, :coin_balance_history)
       get("/:address_hash/coin-balance-history-by-day", V2.AddressController, :coin_balance_history_by_day)
       get("/:address_hash/withdrawals", V2.AddressController, :withdrawals)
+      get("/:address_hash/forward-transfers", V2.AddressController, :forward_transfers)
+    end
+
+    scope "/forward-transfers" do
+      get("/", V2.ForwardTransferController, :forward_transfers)
     end
 
     scope "/tokens" do

--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -170,6 +170,7 @@ defmodule BlockScoutWeb.ApiRouter do
       get("/:block_hash_or_number/transactions", V2.BlockController, :transactions)
       get("/:block_hash_or_number/withdrawals", V2.BlockController, :withdrawals)
       get("/:block_hash_or_number/forward-transfers", V2.BlockController, :forward_transfers)
+      get("/:block_hash_or_number/fee-payments", V2.BlockController, :fee_payments)
     end
 
     scope "/addresses" do
@@ -187,10 +188,15 @@ defmodule BlockScoutWeb.ApiRouter do
       get("/:address_hash/coin-balance-history-by-day", V2.AddressController, :coin_balance_history_by_day)
       get("/:address_hash/withdrawals", V2.AddressController, :withdrawals)
       get("/:address_hash/forward-transfers", V2.AddressController, :forward_transfers)
+      get("/:address_hash/fee-payments", V2.AddressController, :fee_payments)
     end
 
     scope "/forward-transfers" do
       get("/", V2.ForwardTransferController, :forward_transfers)
+    end
+
+    scope "/fee-payments" do
+      get("/", V2.FeePaymentsController, :fee_payments)
     end
 
     scope "/tokens" do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_forward_transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_forward_transfer_controller.ex
@@ -37,7 +37,7 @@ defmodule BlockScoutWeb.AddressForwardTransferController do
         |> Keyword.merge(paging_options(params))
         |> Keyword.merge(current_filter(params))
 
-      results_plus_one = Chain.address_to_forward_transfers(address_hash, options)
+      results_plus_one = Chain.get_forward_transfers(address_hash, nil, options)
       {results, next_page} = split_list_by_page(results_plus_one)
 
       next_page_url =

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -1,8 +1,6 @@
 defmodule BlockScoutWeb.API.V2.AddressController do
   use BlockScoutWeb, :controller
 
-  require Logger
-
   import BlockScoutWeb.Chain,
     only: [
       next_page_params: 3,

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -411,10 +411,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
       |> Keyword.merge(paging_options(params))
       |> Keyword.merge(current_filter(params))
 
-      results =
-        address_hash
-        |> Chain.address_to_forward_transfers(options)
-
+      results = Chain.get_forward_transfers(address_hash, nil, options)
       {forward_transfers, next_page} = split_list_by_page(results)
 
       next_page_params =

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -1,6 +1,8 @@
 defmodule BlockScoutWeb.API.V2.AddressController do
   use BlockScoutWeb, :controller
 
+  require Logger
+
   import BlockScoutWeb.Chain,
     only: [
       next_page_params: 3,
@@ -15,7 +17,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     only: [delete_parameters_from_next_page_params: 1, token_transfers_types_options: 1]
 
   alias BlockScoutWeb.AccessHelper
-  alias BlockScoutWeb.API.V2.{BlockView, TransactionView, WithdrawalView}
+  alias BlockScoutWeb.API.V2.{BlockView, TransactionView, WithdrawalView, ForwardTransferView}
   alias Explorer.{Chain, Market}
   alias Indexer.Fetcher.{CoinBalanceOnDemand, TokenBalanceOnDemand}
 
@@ -40,6 +42,13 @@ defmodule BlockScoutWeb.API.V2.AddressController do
       :transaction => :optional
     },
     api?: true
+  ]
+
+  @forward_transfer_necessity_by_association [
+    necessity_by_association: %{
+      :block => :optional,
+      :to_address => :optional
+    }
   ]
 
   @address_options [
@@ -389,6 +398,32 @@ defmodule BlockScoutWeb.API.V2.AddressController do
       |> put_status(200)
       |> put_view(WithdrawalView)
       |> render(:withdrawals, %{withdrawals: withdrawals, next_page_params: next_page_params})
+    end
+  end
+
+  def forward_transfers(conn, %{"address_hash" => address_hash_string} = params) do
+    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
+         {:ok, false} <- AccessHelper.restricted_access?(address_hash_string, params),
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, @api_true, false)} do
+
+      options =
+      @forward_transfer_necessity_by_association
+      |> Keyword.merge(paging_options(params))
+      |> Keyword.merge(current_filter(params))
+
+      results =
+        address_hash
+        |> Chain.address_to_forward_transfers(options)
+
+      {forward_transfers, next_page} = split_list_by_page(results)
+
+      next_page_params =
+        next_page |> next_page_params(forward_transfers, params) |> delete_parameters_from_next_page_params()
+
+      conn
+      |> put_status(200)
+      |> put_view(ForwardTransferView)
+      |> render(:forward_transfers, %{forward_transfers: forward_transfers, next_page_params: next_page_params})
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -1,18 +1,21 @@
 defmodule BlockScoutWeb.API.V2.BlockController do
   use BlockScoutWeb, :controller
 
+  require Logger
+
   import BlockScoutWeb.Chain,
     only: [
       next_page_params: 3,
       paging_options: 1,
       put_key_value_to_paging_options: 3,
       split_list_by_page: 1,
-      parse_block_hash_or_number_param: 1
+      parse_block_hash_or_number_param: 1,
+      current_filter: 1
     ]
 
   import BlockScoutWeb.PagingHelper, only: [delete_parameters_from_next_page_params: 1, select_block_type: 1]
 
-  alias BlockScoutWeb.API.V2.{TransactionView, WithdrawalView}
+  alias BlockScoutWeb.API.V2.{TransactionView, WithdrawalView, ForwardTransferView}
   alias Explorer.Chain
 
   @transaction_necessity_by_association [
@@ -24,6 +27,13 @@ defmodule BlockScoutWeb.API.V2.BlockController do
       [created_contract_address: :smart_contract] => :optional,
       [from_address: :smart_contract] => :optional,
       [to_address: :smart_contract] => :optional
+    }
+  ]
+
+  @forward_transfer_necessity_by_association [
+    necessity_by_association: %{
+      :block => :optional,
+      :to_address => :optional
     }
   ]
 
@@ -126,4 +136,26 @@ defmodule BlockScoutWeb.API.V2.BlockController do
       |> render(:withdrawals, %{withdrawals: withdrawals, next_page_params: next_page_params})
     end
   end
+
+  def forward_transfers(conn, %{"block_hash_or_number" => block_hash_or_number} = params) do
+    with {:ok, type, value} <- parse_block_hash_or_number_param(block_hash_or_number),
+         {:ok, block} <- fetch_block(type, value, @api_true) do
+
+      full_options =
+        @forward_transfer_necessity_by_association
+        |> Keyword.merge(paging_options(params))
+        |> Keyword.merge(current_filter(params))
+
+      forward_transfers_plus_one = Chain.block_to_forward_transfers(block.hash, full_options)
+      {forward_transfers, next_page} = split_list_by_page(forward_transfers_plus_one)
+
+      next_page_params = next_page |> next_page_params(forward_transfers, params) |> delete_parameters_from_next_page_params()
+
+      conn
+      |> put_status(200)
+      |> put_view(ForwardTransferView)
+      |> render(:forward_transfers, %{forward_transfers: forward_transfers, next_page_params: next_page_params})
+    end
+  end
+
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -146,7 +146,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
         |> Keyword.merge(paging_options(params))
         |> Keyword.merge(current_filter(params))
 
-      forward_transfers_plus_one = Chain.block_to_forward_transfers(block.hash, full_options)
+      forward_transfers_plus_one = Chain.get_forward_transfers(nil, block.hash, full_options)
       {forward_transfers, next_page} = split_list_by_page(forward_transfers_plus_one)
 
       next_page_params = next_page |> next_page_params(forward_transfers, params) |> delete_parameters_from_next_page_params()

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -1,8 +1,6 @@
 defmodule BlockScoutWeb.API.V2.BlockController do
   use BlockScoutWeb, :controller
 
-  require Logger
-
   import BlockScoutWeb.Chain,
     only: [
       next_page_params: 3,

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fee_payments_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fee_payments_controller.ex
@@ -1,8 +1,6 @@
 defmodule BlockScoutWeb.API.V2.FeePaymentsController do
   use BlockScoutWeb, :controller
 
-  require Logger
-
   import BlockScoutWeb.Chain,
     only: [
       next_page_params: 3,

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fee_payments_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fee_payments_controller.ex
@@ -1,0 +1,48 @@
+defmodule BlockScoutWeb.API.V2.FeePaymentsController do
+  use BlockScoutWeb, :controller
+
+  require Logger
+
+  import BlockScoutWeb.Chain,
+    only: [
+      next_page_params: 3,
+      paging_options: 1,
+      split_list_by_page: 1,
+      current_filter: 1
+    ]
+
+  import BlockScoutWeb.PagingHelper,
+    only: [delete_parameters_from_next_page_params: 1]
+
+  alias BlockScoutWeb.API.V2.FeePaymentView
+  alias Explorer.Chain
+
+  @fee_payments_necessity_by_association [
+    necessity_by_association: %{
+      :block => :optional,
+      :to_address => :optional
+    }
+  ]
+
+  action_fallback(BlockScoutWeb.API.V2.FallbackController)
+
+  def fee_payments(conn, params) do
+    options =
+      @fee_payments_necessity_by_association
+      |> Keyword.merge(paging_options(params))
+      |> Keyword.merge(current_filter(params))
+
+    results = Chain.get_fee_payments(nil, nil, options)
+    {fee_payments, next_page} = split_list_by_page(results)
+
+    next_page_params =
+      next_page |> next_page_params(fee_payments, params) |> delete_parameters_from_next_page_params()
+
+    conn
+    |> put_status(200)
+    |> put_view(FeePaymentView)
+    |> render(:fee_payments, %{fee_payments: fee_payments, next_page_params: next_page_params})
+
+  end
+
+end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/forward_transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/forward_transfer_controller.ex
@@ -32,8 +32,7 @@ defmodule BlockScoutWeb.API.V2.ForwardTransferController do
       |> Keyword.merge(paging_options(params))
       |> Keyword.merge(current_filter(params))
 
-    results = Chain.all_forward_transfers(options)
-
+    results = Chain.get_forward_transfers(nil, nil, options)
     {forward_transfers, next_page} = split_list_by_page(results)
 
     next_page_params =

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/forward_transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/forward_transfer_controller.ex
@@ -1,8 +1,6 @@
 defmodule BlockScoutWeb.API.V2.ForwardTransferController do
   use BlockScoutWeb, :controller
 
-  require Logger
-
   import BlockScoutWeb.Chain,
     only: [
       next_page_params: 3,

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/forward_transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/forward_transfer_controller.ex
@@ -1,0 +1,49 @@
+defmodule BlockScoutWeb.API.V2.ForwardTransferController do
+  use BlockScoutWeb, :controller
+
+  require Logger
+
+  import BlockScoutWeb.Chain,
+    only: [
+      next_page_params: 3,
+      paging_options: 1,
+      split_list_by_page: 1,
+      current_filter: 1
+    ]
+
+  import BlockScoutWeb.PagingHelper,
+    only: [delete_parameters_from_next_page_params: 1]
+
+  alias BlockScoutWeb.API.V2.ForwardTransferView
+  alias Explorer.Chain
+
+  @forward_transfer_necessity_by_association [
+    necessity_by_association: %{
+      :block => :optional,
+      :to_address => :optional
+    }
+  ]
+
+  action_fallback(BlockScoutWeb.API.V2.FallbackController)
+
+  def forward_transfers(conn, params) do
+    options =
+      @forward_transfer_necessity_by_association
+      |> Keyword.merge(paging_options(params))
+      |> Keyword.merge(current_filter(params))
+
+    results = Chain.all_forward_transfers(options)
+
+    {forward_transfers, next_page} = split_list_by_page(results)
+
+    next_page_params =
+      next_page |> next_page_params(forward_transfers, params) |> delete_parameters_from_next_page_params()
+
+    conn
+    |> put_status(200)
+    |> put_view(ForwardTransferView)
+    |> render(:forward_transfers, %{forward_transfers: forward_transfers, next_page_params: next_page_params})
+
+  end
+
+end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/fee_payment_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/fee_payment_view.ex
@@ -12,10 +12,11 @@ defmodule BlockScoutWeb.API.V2.FeePaymentView do
   def prepare_fee_payments(fee_payments, _conn) do
 
     %{
+      "to_address" => fee_payments.to_address_hash,
+      "value" => fee_payments.value,
       "block_number" => fee_payments.block_number,
       "block_hash" => fee_payments.block_hash,
-      "to_address" => fee_payments.to_address_hash,
-      "value" => fee_payments.value
+      "index" => fee_payments.index
     }
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/fee_payment_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/fee_payment_view.ex
@@ -1,18 +1,15 @@
 defmodule BlockScoutWeb.API.V2.FeePaymentView do
   use BlockScoutWeb, :view
-
-  def render("message.json", assigns) do
-    ApiView.render("message.json", assigns)
-  end
+  alias Explorer.Chain.Address
 
   def render("fee_payments.json", %{fee_payments: fee_payments, next_page_params: next_page_params}) do
     %{"items" => Enum.map(fee_payments, &prepare_fee_payments(&1, nil)), "next_page_params" => next_page_params}
   end
 
-  def prepare_fee_payments(fee_payments, _conn) do
+  def prepare_fee_payment(fee_payments, _conn) do
 
     %{
-      "to_address" => fee_payments.to_address_hash,
+      "to_address" => Address.checksum(fee_payments.to_address_hash),
       "value" => fee_payments.value,
       "block_number" => fee_payments.block_number,
       "block_hash" => fee_payments.block_hash,

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/fee_payment_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/fee_payment_view.ex
@@ -1,0 +1,22 @@
+defmodule BlockScoutWeb.API.V2.FeePaymentView do
+  use BlockScoutWeb, :view
+
+  def render("message.json", assigns) do
+    ApiView.render("message.json", assigns)
+  end
+
+  def render("fee_payments.json", %{fee_payments: fee_payments, next_page_params: next_page_params}) do
+    %{"items" => Enum.map(fee_payments, &prepare_fee_payments(&1, nil)), "next_page_params" => next_page_params}
+  end
+
+  def prepare_fee_payments(fee_payments, _conn) do
+
+    %{
+      "block_number" => fee_payments.block_number,
+      "block_hash" => fee_payments.block_hash,
+      "to_address" => fee_payments.to_address_hash,
+      "value" => fee_payments.value
+    }
+  end
+
+end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/fee_payment_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/fee_payment_view.ex
@@ -6,14 +6,14 @@ defmodule BlockScoutWeb.API.V2.FeePaymentView do
     %{"items" => Enum.map(fee_payments, &prepare_fee_payment(&1, nil)), "next_page_params" => next_page_params}
   end
 
-  def prepare_fee_payment(fee_payments, _conn) do
+  def prepare_fee_payment(fee_payment, _conn) do
 
     %{
-      "to_address" => Address.checksum(fee_payments.to_address_hash),
-      "value" => fee_payments.value,
-      "block_number" => fee_payments.block_number,
-      "block_hash" => fee_payments.block_hash,
-      "index" => fee_payments.index
+      "to_address" => Address.checksum(fee_payment.to_address_hash),
+      "value" => fee_payment.value,
+      "block_number" => fee_payment.block_number,
+      "block_hash" => fee_payment.block_hash,
+      "index" => fee_payment.index
     }
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/fee_payment_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/fee_payment_view.ex
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.API.V2.FeePaymentView do
   alias Explorer.Chain.Address
 
   def render("fee_payments.json", %{fee_payments: fee_payments, next_page_params: next_page_params}) do
-    %{"items" => Enum.map(fee_payments, &prepare_fee_payments(&1, nil)), "next_page_params" => next_page_params}
+    %{"items" => Enum.map(fee_payments, &prepare_fee_payment(&1, nil)), "next_page_params" => next_page_params}
   end
 
   def prepare_fee_payment(fee_payments, _conn) do

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/forward_transfer_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/forward_transfer_view.ex
@@ -1,18 +1,15 @@
 defmodule BlockScoutWeb.API.V2.ForwardTransferView do
   use BlockScoutWeb, :view
-
-  def render("message.json", assigns) do
-    ApiView.render("message.json", assigns)
-  end
+  alias Explorer.Chain.Address
 
   def render("forward_transfers.json", %{forward_transfers: forward_transfers, next_page_params: next_page_params}) do
     %{"items" => Enum.map(forward_transfers, &prepare_forward_transfers(&1, nil)), "next_page_params" => next_page_params}
   end
 
-  def prepare_forward_transfers(forward_transfer, _conn) do
+  def prepare_forward_transfer(forward_transfer, _conn) do
 
     %{
-      "to_address" => forward_transfer.to_address_hash,
+      "to_address" => Address.checksum(forward_transfer.to_address_hash),
       "value" => forward_transfer.value,
       "block_number" => forward_transfer.block_number,
       "block_hash" => forward_transfer.block_hash,

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/forward_transfer_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/forward_transfer_view.ex
@@ -1,15 +1,6 @@
 defmodule BlockScoutWeb.API.V2.ForwardTransferView do
   use BlockScoutWeb, :view
 
-  import BlockScoutWeb.Account.AuthController, only: [current_user: 1]
-
-  alias BlockScoutWeb.AddressView
-  alias BlockScoutWeb.API.V2.{ApiView, Helper, TokenView}
-  alias BlockScoutWeb.API.V2.Helper
-  alias Explorer.{Chain, Market}
-  alias Explorer.Chain.{Address, SmartContract}
-  require Logger
-
   def render("message.json", assigns) do
     ApiView.render("message.json", assigns)
   end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/forward_transfer_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/forward_transfer_view.ex
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.API.V2.ForwardTransferView do
   alias Explorer.Chain.Address
 
   def render("forward_transfers.json", %{forward_transfers: forward_transfers, next_page_params: next_page_params}) do
-    %{"items" => Enum.map(forward_transfers, &prepare_forward_transfers(&1, nil)), "next_page_params" => next_page_params}
+    %{"items" => Enum.map(forward_transfers, &prepare_forward_transfer(&1, nil)), "next_page_params" => next_page_params}
   end
 
   def prepare_forward_transfer(forward_transfer, _conn) do

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/forward_transfer_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/forward_transfer_view.ex
@@ -12,10 +12,11 @@ defmodule BlockScoutWeb.API.V2.ForwardTransferView do
   def prepare_forward_transfers(forward_transfer, _conn) do
 
     %{
+      "to_address" => forward_transfer.to_address_hash,
+      "value" => forward_transfer.value,
       "block_number" => forward_transfer.block_number,
       "block_hash" => forward_transfer.block_hash,
-      "to_address" => forward_transfer.to_address_hash,
-      "value" => forward_transfer.value
+      "index" => forward_transfer.index
     }
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/forward_transfer_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/forward_transfer_view.ex
@@ -1,0 +1,31 @@
+defmodule BlockScoutWeb.API.V2.ForwardTransferView do
+  use BlockScoutWeb, :view
+
+  import BlockScoutWeb.Account.AuthController, only: [current_user: 1]
+
+  alias BlockScoutWeb.AddressView
+  alias BlockScoutWeb.API.V2.{ApiView, Helper, TokenView}
+  alias BlockScoutWeb.API.V2.Helper
+  alias Explorer.{Chain, Market}
+  alias Explorer.Chain.{Address, SmartContract}
+  require Logger
+
+  def render("message.json", assigns) do
+    ApiView.render("message.json", assigns)
+  end
+
+  def render("forward_transfers.json", %{forward_transfers: forward_transfers, next_page_params: next_page_params}) do
+    %{"items" => Enum.map(forward_transfers, &prepare_forward_transfers(&1, nil)), "next_page_params" => next_page_params}
+  end
+
+  def prepare_forward_transfers(forward_transfer, _conn) do
+
+    %{
+      "block_number" => forward_transfer.block_number,
+      "block_hash" => forward_transfer.block_hash,
+      "to_address" => forward_transfer.to_address_hash,
+      "value" => forward_transfer.value
+    }
+  end
+
+end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -15,7 +15,8 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
     Transaction,
     Withdrawal,
     ForwardTransfer,
-    FeePayment
+    FeePayment,
+    Wei
   }
 
   alias Explorer.Account.WatchlistAddress
@@ -1853,15 +1854,15 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
     assert Address.checksum(forward_transfer.to_address_hash) == json["to_address"]
     assert forward_transfer.block_number == json["block_number"]
     assert to_string(forward_transfer.block_hash) == json["block_hash"]
-    assert 0 == json["index"]
+    assert Wei.cast(json["value"]) == {:ok, forward_transfer.value}
   end
 
-  defp compare_item(%FeePayment{} = forward_transfer, json) do
-    assert forward_transfer.index == json["index"]
-    assert Address.checksum(forward_transfer.to_address_hash) == json["to_address"]
-    assert forward_transfer.block_number == json["block_number"]
-    assert to_string(forward_transfer.block_hash) == json["block_hash"]
-    assert 0 == json["index"]
+  defp compare_item(%FeePayment{} = fee_payment, json) do
+    assert fee_payment.index == json["index"]
+    assert Address.checksum(fee_payment.to_address_hash) == json["to_address"]
+    assert fee_payment.block_number == json["block_number"]
+    assert to_string(fee_payment.block_hash) == json["block_hash"]
+    assert Wei.cast(json["value"]) == {:ok, fee_payment.value}
   end
 
   defp check_paginated_response(first_page_resp, second_page_resp, list) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -1638,16 +1638,44 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert %{"message" => "Invalid parameter(s)"} = json_response(request, 422)
     end
 
-    test "get forward transfer", %{conn: conn} do
+    test "get forward transfers", %{conn: conn} do
+      address = insert(:address)
+      forward_transfers = insert_list(3, :forward_transfer_same_address, to_address: address)
+      [forward_transfer | _] = Enum.reverse(forward_transfers)
 
-      forward_transfer = insert(:forward_transfer)
-
-      request = get(conn, "/api/v2/addresses/#{forward_transfer.to_address_hash}/fee-payments")
+      request = get(conn, "/api/v2/addresses/#{address.hash}/forward-transfers")
       assert response = json_response(request, 200)
-      assert Enum.count(response["items"]) == 1
+      assert Enum.count(response["items"]) == 3
       assert response["next_page_params"] == nil
       compare_item(forward_transfer, Enum.at(response["items"], 0))
+
+      request = get(conn, "/api/v2/addresses/#{address.hash}/forward-transfers")
+      assert response_1 = json_response(request, 200)
+      assert response_1 == response
     end
+
+    test "get forward tranfers with working next_page_params", %{conn: conn} do
+      address = insert(:address)
+      forward_transfers = insert_list(51, :forward_transfer_same_address, to_address: address)
+
+      request = get(conn, "/api/v2/addresses/#{address.hash}/forward-transfers")
+      assert response = json_response(request, 200)
+
+      request_2nd_page = get(conn, "/api/v2/addresses/#{address.hash}/forward-transfers", response["next_page_params"])
+      assert response_2nd_page = json_response(request_2nd_page, 200)
+
+      check_paginated_response(response, response_2nd_page, forward_transfers)
+
+      request_1 = get(conn, "/api/v2/addresses/#{address.hash}/forward-transfers")
+      assert response_1 = json_response(request_1, 200)
+
+      assert response_1 == response
+
+      request_2 = get(conn, "/api/v2/addresses/#{address.hash}/forward-transfers", response_1["next_page_params"])
+      assert response_2 = json_response(request_2, 200)
+      assert response_2 == response_2nd_page
+    end
+
   end
 
   describe "/addresses/{address_hash}/fee-payments" do
@@ -1665,16 +1693,44 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert %{"message" => "Invalid parameter(s)"} = json_response(request, 422)
     end
 
-    test "get fee payment", %{conn: conn} do
+    test "get fee payments", %{conn: conn} do
+      address = insert(:address)
+      fee_payments = insert_list(3, :fee_payment_same_address, to_address: address)
+      [fee_payment | _] = Enum.reverse(fee_payments)
 
-      fee_payment = insert(:fee_payment)
-
-      request = get(conn, "/api/v2/addresses/#{fee_payment.to_address_hash}/fee-payments")
+      request = get(conn, "/api/v2/addresses/#{address.hash}/fee-payments")
       assert response = json_response(request, 200)
-      assert Enum.count(response["items"]) == 1
+      assert Enum.count(response["items"]) == 3
       assert response["next_page_params"] == nil
       compare_item(fee_payment, Enum.at(response["items"], 0))
+
+      request = get(conn, "/api/v2/addresses/#{address.hash}/fee-payments")
+      assert response_1 = json_response(request, 200)
+      assert response_1 == response
     end
+
+    test "get fee payments with working next_page_params", %{conn: conn} do
+      address = insert(:address)
+      fee_payments = insert_list(51, :fee_payment_same_address, to_address: address)
+
+      request = get(conn, "/api/v2/addresses/#{address.hash}/fee-payments")
+      assert response = json_response(request, 200)
+
+      request_2nd_page = get(conn, "/api/v2/addresses/#{address.hash}/fee-payments", response["next_page_params"])
+      assert response_2nd_page = json_response(request_2nd_page, 200)
+
+      check_paginated_response(response, response_2nd_page, fee_payments)
+
+      request_1 = get(conn, "/api/v2/addresses/#{address.hash}/fee-payments")
+      assert response_1 = json_response(request_1, 200)
+
+      assert response_1 == response
+
+      request_2 = get(conn, "/api/v2/addresses/#{address.hash}/fee-payments", response_1["next_page_params"])
+      assert response_2 = json_response(request_2, 200)
+      assert response_2 == response_2nd_page
+    end
+
   end
 
   describe "/addresses" do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -416,18 +416,41 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
     end
 
     test "get forward tranfers", %{conn: conn} do
+      block = insert(:block)
+      forward_transfers = insert_list(3, :forward_transfer_same_block, block: block)
+      [forward_transfer | _] = Enum.reverse(forward_transfers)
 
-      forward_transfer = insert(:forward_transfer)
-
-      request = get(conn, "/api/v2/blocks/#{forward_transfer.block_number}/forward-transfers")
+      request = get(conn, "/api/v2/blocks/#{block.number}/forward-transfers")
       assert response = json_response(request, 200)
-      assert Enum.count(response["items"]) == 1
+      assert Enum.count(response["items"]) == 3
       assert response["next_page_params"] == nil
       compare_item(forward_transfer, Enum.at(response["items"], 0))
 
-      request = get(conn, "/api/v2/blocks/#{forward_transfer.block_hash}/forward-transfers")
+      request = get(conn, "/api/v2/blocks/#{block.hash}/forward-transfers")
       assert response_1 = json_response(request, 200)
       assert response_1 == response
+    end
+
+    test "get forward tranfers with working next_page_params", %{conn: conn} do
+      block = insert(:block)
+      forward_transfers = insert_list(51, :forward_transfer_same_block, block: block)
+
+      request = get(conn, "/api/v2/blocks/#{block.number}/forward-transfers")
+      assert response = json_response(request, 200)
+
+      request_2nd_page = get(conn, "/api/v2/blocks/#{block.number}/forward-transfers", response["next_page_params"])
+      assert response_2nd_page = json_response(request_2nd_page, 200)
+
+      check_paginated_response(response, response_2nd_page, forward_transfers)
+
+      request_1 = get(conn, "/api/v2/blocks/#{block.hash}/forward-transfers")
+      assert response_1 = json_response(request_1, 200)
+
+      assert response_1 == response
+
+      request_2 = get(conn, "/api/v2/blocks/#{block.hash}/forward-transfers", response_1["next_page_params"])
+      assert response_2 = json_response(request_2, 200)
+      assert response_2 == response_2nd_page
     end
 
   end
@@ -466,18 +489,42 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
     end
 
     test "get fee payments", %{conn: conn} do
+      block = insert(:block)
+      fee_payments = insert_list(3, :fee_payment_same_block, block: block)
+      [fee_payment | _] = Enum.reverse(fee_payments)
 
-      fee_payment = insert(:fee_payment)
-
-      request = get(conn, "/api/v2/blocks/#{fee_payment.block_number}/fee-payments")
+      request = get(conn, "/api/v2/blocks/#{block.number}/fee-payments")
       assert response = json_response(request, 200)
-      assert Enum.count(response["items"]) == 1
+      assert Enum.count(response["items"]) == 3
       assert response["next_page_params"] == nil
       compare_item(fee_payment, Enum.at(response["items"], 0))
 
-      request = get(conn, "/api/v2/blocks/#{fee_payment.block_hash}/fee-payments")
+      request = get(conn, "/api/v2/blocks/#{block.hash}/fee-payments")
       assert response_1 = json_response(request, 200)
       assert response_1 == response
+    end
+
+    test "get fee payments with working next_page_params", %{conn: conn} do
+
+      block = insert(:block)
+      fee_payments = insert_list(51, :fee_payment_same_block, block: block)
+
+      request = get(conn, "/api/v2/blocks/#{block.number}/fee-payments")
+      assert response = json_response(request, 200)
+
+      request_2nd_page = get(conn, "/api/v2/blocks/#{block.number}/fee-payments", response["next_page_params"])
+      assert response_2nd_page = json_response(request_2nd_page, 200)
+
+      check_paginated_response(response, response_2nd_page, fee_payments)
+
+      request_1 = get(conn, "/api/v2/blocks/#{block.hash}/fee-payments")
+      assert response_1 = json_response(request_1, 200)
+
+      assert response_1 == response
+
+      request_2 = get(conn, "/api/v2/blocks/#{block.hash}/fee-payments", response_1["next_page_params"])
+      assert response_2 = json_response(request_2, 200)
+      assert response_2 == response_2nd_page
     end
 
   end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.API.V2.BlockControllerTest do
   use BlockScoutWeb.ConnCase
 
-  alias Explorer.Chain.{Address, Block, Transaction, Withdrawal, ForwardTransfer, FeePayment}
+  alias Explorer.Chain.{Address, Block, Transaction, Withdrawal, ForwardTransfer, FeePayment, Wei}
 
   setup do
     Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.Blocks.child_id())
@@ -551,15 +551,15 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
     assert Address.checksum(forward_transfer.to_address_hash) == json["to_address"]
     assert forward_transfer.block_number == json["block_number"]
     assert to_string(forward_transfer.block_hash) == json["block_hash"]
-    assert 0 == json["index"]
+    assert Wei.cast(json["value"]) == {:ok, forward_transfer.value}
   end
 
-  defp compare_item(%FeePayment{} = forward_transfer, json) do
-    assert forward_transfer.index == json["index"]
-    assert Address.checksum(forward_transfer.to_address_hash) == json["to_address"]
-    assert forward_transfer.block_number == json["block_number"]
-    assert to_string(forward_transfer.block_hash) == json["block_hash"]
-    assert 0 == json["index"]
+  defp compare_item(%FeePayment{} = fee_payment, json) do
+    assert fee_payment.index == json["index"]
+    assert Address.checksum(fee_payment.to_address_hash) == json["to_address"]
+    assert fee_payment.block_number == json["block_number"]
+    assert to_string(fee_payment.block_hash) == json["block_hash"]
+    assert Wei.cast(json["value"]) == {:ok, fee_payment.value}
   end
 
   defp check_paginated_response(first_page_resp, second_page_resp, list) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/fee_payment_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/fee_payment_controller_test.exs
@@ -1,0 +1,71 @@
+defmodule BlockScoutWeb.API.V2.FeePaymentControllerTest do
+  use BlockScoutWeb.ConnCase
+
+  alias Explorer.Chain.{Address, FeePayment}
+
+  describe "/fee-payment" do
+
+    test "get empty list", %{conn: conn} do
+      request = get(conn, "/api/v2/fee-payments")
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+    end
+
+    test "get fee payments", %{conn: conn} do
+      fee_payments = insert_list(3, :fee_payment)
+      [fee_payment | _] = Enum.reverse(fee_payments)
+
+      request = get(conn, "/api/v2/fee-payments")
+      assert response = json_response(request, 200)
+      assert Enum.count(response["items"]) == 3
+      assert response["next_page_params"] == nil
+      compare_item(fee_payment, Enum.at(response["items"], 0))
+
+      request = get(conn, "/api/v2/fee-payments")
+      assert response_1 = json_response(request, 200)
+      assert response_1 == response
+    end
+
+    test "get fee payments with working next_page_params", %{conn: conn} do
+      fee_payments = insert_list(51, :fee_payment)
+
+      request = get(conn, "/api/v2/fee-payments")
+      assert response = json_response(request, 200)
+
+      request_2nd_page = get(conn, "/api/v2/fee-payments", response["next_page_params"])
+      assert response_2nd_page = json_response(request_2nd_page, 200)
+
+      check_paginated_response(response, response_2nd_page, fee_payments)
+
+      request_1 = get(conn, "/api/v2/fee-payments")
+      assert response_1 = json_response(request_1, 200)
+
+      assert response_1 == response
+
+      request_2 = get(conn, "/api/v2/fee-payments", response_1["next_page_params"])
+      assert response_2 = json_response(request_2, 200)
+      assert response_2 == response_2nd_page
+    end
+
+  end
+
+  defp compare_item(%FeePayment{} = fee_payment, json) do
+    assert fee_payment.index == json["index"]
+    assert Address.checksum(fee_payment.to_address_hash) == json["to_address"]
+    assert fee_payment.block_number == json["block_number"]
+    assert to_string(fee_payment.block_hash) == json["block_hash"]
+    assert 0 == json["index"]
+  end
+
+  defp check_paginated_response(first_page_resp, second_page_resp, list) do
+    assert Enum.count(first_page_resp["items"]) == 50
+    assert first_page_resp["next_page_params"] != nil
+    compare_item(Enum.at(list, 50), Enum.at(first_page_resp["items"], 0))
+    compare_item(Enum.at(list, 1), Enum.at(first_page_resp["items"], 49))
+
+    assert Enum.count(second_page_resp["items"]) == 1
+    assert second_page_resp["next_page_params"] == nil
+    compare_item(Enum.at(list, 0), Enum.at(second_page_resp["items"], 0))
+  end
+end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/fee_payment_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/fee_payment_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.API.V2.FeePaymentControllerTest do
   use BlockScoutWeb.ConnCase
 
-  alias Explorer.Chain.{Address, FeePayment}
+  alias Explorer.Chain.{Address, FeePayment, Wei}
 
   describe "/fee-payment" do
 
@@ -55,7 +55,7 @@ defmodule BlockScoutWeb.API.V2.FeePaymentControllerTest do
     assert Address.checksum(fee_payment.to_address_hash) == json["to_address"]
     assert fee_payment.block_number == json["block_number"]
     assert to_string(fee_payment.block_hash) == json["block_hash"]
-    assert 0 == json["index"]
+    assert Wei.cast(json["value"]) == {:ok, fee_payment.value}
   end
 
   defp check_paginated_response(first_page_resp, second_page_resp, list) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/forward_transfer_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/forward_transfer_controller_test.exs
@@ -1,0 +1,71 @@
+defmodule BlockScoutWeb.API.V2.ForwardTransferControllerTest do
+  use BlockScoutWeb.ConnCase
+
+  alias Explorer.Chain.{Address, ForwardTransfer}
+
+  describe "/forward-transfers" do
+
+    test "get empty list", %{conn: conn} do
+      request = get(conn, "/api/v2/forward-transfers")
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+    end
+
+    test "get forward tranfers", %{conn: conn} do
+      forward_transfers = insert_list(3, :forward_transfer)
+      [forward_transfer | _] = Enum.reverse(forward_transfers)
+
+      request = get(conn, "/api/v2/forward-transfers")
+      assert response = json_response(request, 200)
+      assert Enum.count(response["items"]) == 3
+      assert response["next_page_params"] == nil
+      compare_item(forward_transfer, Enum.at(response["items"], 0))
+
+      request = get(conn, "/api/v2/forward-transfers")
+      assert response_1 = json_response(request, 200)
+      assert response_1 == response
+    end
+
+    test "get forward tranfers with working next_page_params", %{conn: conn} do
+      forward_transfers = insert_list(51, :forward_transfer)
+
+      request = get(conn, "/api/v2/forward-transfers")
+      assert response = json_response(request, 200)
+
+      request_2nd_page = get(conn, "/api/v2/forward-transfers", response["next_page_params"])
+      assert response_2nd_page = json_response(request_2nd_page, 200)
+
+      check_paginated_response(response, response_2nd_page, forward_transfers)
+
+      request_1 = get(conn, "/api/v2/forward-transfers")
+      assert response_1 = json_response(request_1, 200)
+
+      assert response_1 == response
+
+      request_2 = get(conn, "/api/v2/forward-transfers", response_1["next_page_params"])
+      assert response_2 = json_response(request_2, 200)
+      assert response_2 == response_2nd_page
+    end
+
+  end
+
+  defp compare_item(%ForwardTransfer{} = forward_transfer, json) do
+    assert forward_transfer.index == json["index"]
+    assert Address.checksum(forward_transfer.to_address_hash) == json["to_address"]
+    assert forward_transfer.block_number == json["block_number"]
+    assert to_string(forward_transfer.block_hash) == json["block_hash"]
+    assert 0 == json["index"]
+  end
+
+  defp check_paginated_response(first_page_resp, second_page_resp, list) do
+    assert Enum.count(first_page_resp["items"]) == 50
+    assert first_page_resp["next_page_params"] != nil
+    compare_item(Enum.at(list, 50), Enum.at(first_page_resp["items"], 0))
+    compare_item(Enum.at(list, 1), Enum.at(first_page_resp["items"], 49))
+
+    assert Enum.count(second_page_resp["items"]) == 1
+    assert second_page_resp["next_page_params"] == nil
+    compare_item(Enum.at(list, 0), Enum.at(second_page_resp["items"], 0))
+  end
+end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/forward_transfer_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/forward_transfer_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.API.V2.ForwardTransferControllerTest do
   use BlockScoutWeb.ConnCase
 
-  alias Explorer.Chain.{Address, ForwardTransfer}
+  alias Explorer.Chain.{Address, ForwardTransfer, Wei}
 
   describe "/forward-transfers" do
 
@@ -55,7 +55,7 @@ defmodule BlockScoutWeb.API.V2.ForwardTransferControllerTest do
     assert Address.checksum(forward_transfer.to_address_hash) == json["to_address"]
     assert forward_transfer.block_number == json["block_number"]
     assert to_string(forward_transfer.block_hash) == json["block_hash"]
-    assert 0 == json["index"]
+    assert Wei.cast(json["value"]) == {:ok, forward_transfer.value}
   end
 
   defp check_paginated_response(first_page_resp, second_page_resp, list) do

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3738,41 +3738,27 @@ defmodule Explorer.Chain do
     |> Repo.all()
   end
 
-  def all_forward_transfers(options \\ []) when is_list(options) do
+  def get_forward_transfers(address_hash \\ nil, block_hash \\ nil, options \\ []) when is_list(options) do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
     ForwardTransfer
+    |> forward_transfers_filter_address_hash(address_hash)
+    |> forward_transfers_filter_block_hash(block_hash)
     |> order_by([forward_transfer], desc: [forward_transfer.block_number, forward_transfer.index])
     |> handle_forward_transfers_paging_options(paging_options)
     |> join_associations(necessity_by_association)
     |> Repo.all()
   end
 
-  def address_to_forward_transfers(address_hash, options \\ []) when is_list(options) do
-    necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
-    paging_options = Keyword.get(options, :paging_options, @default_paging_options)
-
-    ForwardTransfer
-    |> where([ft], ft.to_address_hash == ^address_hash)
-    |> order_by([forward_transfer], desc: [forward_transfer.block_number, forward_transfer.index])
-    |> handle_paging_options(paging_options)
-    |> limit(^paging_options.page_size)
-    |> join_associations(necessity_by_association)
-    |> Repo.all()
+  defp forward_transfers_filter_address_hash(query, nil), do: query
+  defp forward_transfers_filter_address_hash(query, address_hash) do
+    query |> where([ft], ft.to_address_hash == ^address_hash)
   end
 
-  def block_to_forward_transfers(block_hash, options \\ []) when is_list(options) do
-    necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
-    paging_options = Keyword.get(options, :paging_options, @default_paging_options)
-
-    ForwardTransfer
-    |> where([ft], ft.block_hash == ^block_hash)
-    |> order_by([forward_transfer], desc: [forward_transfer.block_number, forward_transfer.index])
-    |> handle_paging_options(paging_options)
-    |> limit(^paging_options.page_size)
-    |> join_associations(necessity_by_association)
-    |> Repo.all()
+  defp forward_transfers_filter_block_hash(query, nil), do: query
+  defp forward_transfers_filter_block_hash(query, block_hash) do
+    query |> where([ft], ft.block_hash == ^block_hash)
   end
 
   def forward_transfers_count do

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -5166,6 +5166,15 @@ defmodule Explorer.Chain do
     )
   end
 
+  defp page_forward_transfers(query, %PagingOptions{key: {block_number, index}}) do
+    where(
+      query,
+      [forward_transfers],
+      forward_transfers.block_number < ^block_number or
+        (forward_transfers.block_number == ^block_number and forward_transfers.index < ^index)
+    )
+  end
+
   defp page_fee_payments(query, %PagingOptions{key: nil}), do: query
 
   defp page_fee_payments(query, %PagingOptions{key: {block_number}}) do
@@ -5174,6 +5183,15 @@ defmodule Explorer.Chain do
       [fee_payments],
       fee_payments.block_number < ^block_number or
         (fee_payments.block_number == ^block_number)
+    )
+  end
+
+  defp page_fee_payments(query, %PagingOptions{key: {block_number, index}}) do
+    where(
+      query,
+      [fee_payments],
+      fee_payments.block_number < ^block_number or
+        (fee_payments.block_number == ^block_number and fee_payments.index < ^index)
     )
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -4042,7 +4042,7 @@ defmodule Explorer.ChainTest do
 
       assert [
                %ForwardTransfer{to_address_hash: expected_address_hash}
-             ] = Chain.address_to_forward_transfers(address1.hash)
+             ] = Chain.get_forward_transfers(address1.hash, nil, nil)
     end
   end
 

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -776,6 +776,30 @@ defmodule Explorer.Factory do
     }
   end
 
+  def forward_transfer_same_block_factory do
+    address = insert(:address)
+
+    %ForwardTransfer{
+      block: build(:block),
+      block_number: build(:block).number,
+      to_address_hash: address.hash,
+      value: Enum.random(1..100_000),
+      index: 0
+    }
+  end
+
+  def forward_transfer_same_address_factory do
+    block = insert(:block)
+
+    %ForwardTransfer{
+      block_number: block.number,
+      block_hash: block.hash,
+      to_address: build(:address),
+      value: Enum.random(1..100_000),
+      index: 0
+    }
+  end
+
   def fee_payment_factory do
     block = insert(:block)
     address = insert(:address)
@@ -784,6 +808,30 @@ defmodule Explorer.Factory do
       block_number: block.number,
       block_hash: block.hash,
       to_address_hash: address.hash,
+      value: Enum.random(1..100_000),
+      index: 0
+    }
+  end
+
+  def fee_payment_same_block_factory do
+    address = insert(:address)
+
+    %FeePayment{
+      block: build(:block),
+      block_number: build(:block).number,
+      to_address_hash: address.hash,
+      value: Enum.random(1..100_000),
+      index: 0
+    }
+  end
+
+  def fee_payment_same_address_factory do
+    block = insert(:block)
+
+    %FeePayment{
+      block_number: block.number,
+      block_hash: block.hash,
+      to_address: build(:address),
       value: Enum.random(1..100_000),
       index: 0
     }

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -772,7 +772,7 @@ defmodule Explorer.Factory do
       block_hash: block.hash,
       to_address_hash: address.hash,
       value: Enum.random(1..100_000),
-      index: 0
+      index: forward_transfer_index()
     }
   end
 
@@ -784,7 +784,7 @@ defmodule Explorer.Factory do
       block_number: build(:block).number,
       to_address_hash: address.hash,
       value: Enum.random(1..100_000),
-      index: 0
+      index: forward_transfer_index()
     }
   end
 
@@ -796,8 +796,12 @@ defmodule Explorer.Factory do
       block_hash: block.hash,
       to_address: build(:address),
       value: Enum.random(1..100_000),
-      index: 0
+      index: forward_transfer_index()
     }
+  end
+
+  def forward_transfer_index do
+    sequence("forward_transfer_index", & &1)
   end
 
   def fee_payment_factory do
@@ -809,7 +813,7 @@ defmodule Explorer.Factory do
       block_hash: block.hash,
       to_address_hash: address.hash,
       value: Enum.random(1..100_000),
-      index: 0
+      index: fee_payment_index()
     }
   end
 
@@ -821,7 +825,7 @@ defmodule Explorer.Factory do
       block_number: build(:block).number,
       to_address_hash: address.hash,
       value: Enum.random(1..100_000),
-      index: 0
+      index: fee_payment_index()
     }
   end
 
@@ -833,8 +837,12 @@ defmodule Explorer.Factory do
       block_hash: block.hash,
       to_address: build(:address),
       value: Enum.random(1..100_000),
-      index: 0
+      index: fee_payment_index()
     }
+  end
+
+  def fee_payment_index do
+    sequence("fee_payment_index", & &1)
   end
 
   def transaction_factory do


### PR DESCRIPTION
The new endpoints related to the forward transfers and fee payments to supply the new frontend were added to the `v2` namespace.
The list of new endpoints are:

for **forward transfers**:
- all forward transfers: `/api/v2/forward-transfers`
- all forward transfers in block: `/api/v2/blocks/<block-hash-or-number>/forward-transfers `
- all forward transfers per address: `/api/v2/addresses/<address-hash>/forward-transfers `

 for **fee payments**:
- all fee payments: `/api/v2/fee-payments`
- all fee payments in block: `/api/v2/blocks/<block-hash-or-number>/fee-payments`
- all fee payments per address: `/api/v2/addresses/<address-hash>/fee-payments`

The pagination logic is executed adding the query parameters `block_number` and `index` to the endpoint path. Pagination parameters are returned by the endpoint if the response size is greater than the default page size for the `v2` namespace that is 50 items, otherwise is _null_.