### PR TITLE
WEB3-86 - backend-version v2 endpoint fix

### DIFF
--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -8,6 +8,8 @@ import Config
 # General application configuration
 config :block_scout_web,
   namespace: BlockScoutWeb,
+  backend_version: Mix.Project.config()[:version],
+  json_rpc_url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
   ecto_repos: [Explorer.Repo, Explorer.Repo.Account],
   cookie_domain: System.get_env("SESSION_COOKIE_DOMAIN"),
   # 604800 seconds, 1 week

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
@@ -2,18 +2,14 @@ defmodule BlockScoutWeb.API.V2.ConfigController do
   use BlockScoutWeb, :controller
 
   def json_rpc_url(conn, _params) do
-    json_rpc_url = Application.get_env(:block_scout_web, :json_rpc)
-
     conn
     |> put_status(200)
-    |> render(:json_rpc_url, %{url: json_rpc_url})
+    |> render(:json_rpc_url, %{url: Application.get_env(:block_scout_web, :json_rpc_url)})
   end
 
   def backend_version(conn, _params) do
-    backend_version = Application.get_env(:block_scout_web, :version)
-
     conn
     |> put_status(200)
-    |> render(:backend_version, %{version: backend_version})
+    |> render(:backend_version, %{version: Application.get_env(:block_scout_web, :backend_version)})
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/config_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/config_controller_test.exs
@@ -2,21 +2,45 @@ defmodule BlockScoutWeb.API.V2.ConfigControllerTest do
   use BlockScoutWeb.ConnCase
 
   describe "/config/json-rpc-url" do
-    test "get json rps url if set", %{conn: conn} do
-      url = "http://rps.url:1234/v1"
-      Application.put_env(:block_scout_web, :json_rpc, url)
+
+    test "get json rpc url if set", %{conn: conn} do
+      url = "http://rpc.url:1234/v1"
+      Application.put_env(:block_scout_web, :json_rpc_url, url)
 
       request = get(conn, "/api/v2/config/json-rpc-url")
 
       assert %{"json_rpc_url" => ^url} = json_response(request, 200)
     end
 
-    test "get empty json rps url if not set", %{conn: conn} do
-      Application.put_env(:block_scout_web, :json_rpc, nil)
+    test "get empty json rpc url if not set", %{conn: conn} do
+      Application.put_env(:block_scout_web, :json_rpc_url, nil)
 
       request = get(conn, "/api/v2/config/json-rpc-url")
 
       assert %{"json_rpc_url" => nil} = json_response(request, 200)
     end
+
   end
+
+  describe "/config/backend-version" do
+
+    test "get backend version if set", %{conn: conn} do
+      backend_version = "1.0.0"
+      Application.put_env(:block_scout_web, :backend_version, backend_version)
+
+      request = get(conn, "/api/v2/config/backend-version")
+
+      assert %{"backend_version" => ^backend_version} = json_response(request, 200)
+    end
+
+    test "get empty backend version if not set", %{conn: conn} do
+      Application.put_env(:block_scout_web, :backend_version, nil)
+
+      request = get(conn, "/api/v2/config/backend-version")
+
+      assert %{"backend_version" => nil} = json_response(request, 200)
+    end
+
+  end
+
 end


### PR DESCRIPTION
In this PR:
- fix of the `/api/v2/config/backend-version` to correctly display the blockscout current version used
- fix of the `/api/v2/config/json-rpc-url` to correctly display the endpoint used for rpc methods