### PR TITLE
[WEB3-559] Expose Gas Price from RPC in api/v2

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
@@ -6,6 +6,7 @@ defmodule BlockScoutWeb.API.V2.StatsController do
   alias Explorer.{Chain, Market}
   alias Explorer.Chain.Cache.Block, as: BlockCache
   alias Explorer.Chain.Cache.{GasPriceOracle, GasUsage}
+  alias Explorer.Chain.GasPrice.GasPrice
   alias Explorer.Chain.Cache.Transaction, as: TransactionCache
   alias Explorer.Chain.Supply.RSK
   alias Explorer.Chain.Transaction.History.TransactionStats
@@ -37,6 +38,15 @@ defmodule BlockScoutWeb.API.V2.StatsController do
           nil
       end
 
+    gas_price_rpc =
+      case GasPrice.get_gas_price_from_rpc() do
+        {:ok, gas_price} ->
+          gas_price
+
+        nil ->
+          nil
+      end
+
     gas_price = Application.get_env(:block_scout_web, :gas_price)
 
     json(
@@ -51,6 +61,7 @@ defmodule BlockScoutWeb.API.V2.StatsController do
         "transactions_today" => Enum.at(transaction_stats, 0).number_of_transactions |> to_string(),
         "gas_used_today" => Enum.at(transaction_stats, 0).gas_used,
         "gas_prices" => gas_prices,
+        "gas_price_rpc" => gas_price_rpc,
         "static_gas_price" => gas_price,
         "market_cap" => Helper.market_cap(market_cap_type, exchange_rate),
         "network_utilization_percentage" => network_utilization_percentage()


### PR DESCRIPTION
For using the gas price that comes from the RPC in the new frontend, we need to expose that information on the api/v2.

This is used on the frontend, as included on this PR: https://github.com/HorizenLabs/blockscout-frontend/pull/8