### PR TITLE
WEB4-631 - timestamp added to forward transfer and fee payments v2 responses

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/fee_payment_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/fee_payment_view.ex
@@ -13,7 +13,8 @@ defmodule BlockScoutWeb.API.V2.FeePaymentView do
       "value" => fee_payment.value,
       "block_number" => fee_payment.block_number,
       "block_hash" => fee_payment.block_hash,
-      "index" => fee_payment.index
+      "index" => fee_payment.index,
+      "timestamp" => fee_payment.block.timestamp
     }
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/forward_transfer_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/forward_transfer_view.ex
@@ -13,7 +13,8 @@ defmodule BlockScoutWeb.API.V2.ForwardTransferView do
       "value" => forward_transfer.value,
       "block_number" => forward_transfer.block_number,
       "block_hash" => forward_transfer.block_hash,
-      "index" => forward_transfer.index
+      "index" => forward_transfer.index,
+      "timestamp" => forward_transfer.block.timestamp
     }
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -1855,6 +1855,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
     assert forward_transfer.block_number == json["block_number"]
     assert to_string(forward_transfer.block_hash) == json["block_hash"]
     assert Wei.cast(json["value"]) == {:ok, forward_transfer.value}
+    assert Jason.encode!(Repo.get_by(Block, hash: forward_transfer.block_hash).timestamp) =~ String.replace(json["timestamp"], "Z", "")
   end
 
   defp compare_item(%FeePayment{} = fee_payment, json) do
@@ -1863,6 +1864,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
     assert fee_payment.block_number == json["block_number"]
     assert to_string(fee_payment.block_hash) == json["block_hash"]
     assert Wei.cast(json["value"]) == {:ok, fee_payment.value}
+    assert Jason.encode!(Repo.get_by(Block, hash: fee_payment.block_hash).timestamp) =~ String.replace(json["timestamp"], "Z", "")
   end
 
   defp check_paginated_response(first_page_resp, second_page_resp, list) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -2,6 +2,7 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
   use BlockScoutWeb.ConnCase
 
   alias Explorer.Chain.{Address, Block, Transaction, Withdrawal, ForwardTransfer, FeePayment, Wei}
+  alias Explorer.Repo
 
   setup do
     Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.Blocks.child_id())
@@ -552,6 +553,7 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
     assert forward_transfer.block_number == json["block_number"]
     assert to_string(forward_transfer.block_hash) == json["block_hash"]
     assert Wei.cast(json["value"]) == {:ok, forward_transfer.value}
+    assert Jason.encode!(Repo.get_by(Block, hash: forward_transfer.block_hash).timestamp) =~ String.replace(json["timestamp"], "Z", "")
   end
 
   defp compare_item(%FeePayment{} = fee_payment, json) do
@@ -560,6 +562,7 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
     assert fee_payment.block_number == json["block_number"]
     assert to_string(fee_payment.block_hash) == json["block_hash"]
     assert Wei.cast(json["value"]) == {:ok, fee_payment.value}
+    assert Jason.encode!(Repo.get_by(Block, hash: fee_payment.block_hash).timestamp) =~ String.replace(json["timestamp"], "Z", "")
   end
 
   defp check_paginated_response(first_page_resp, second_page_resp, list) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/fee_payment_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/fee_payment_controller_test.exs
@@ -1,7 +1,8 @@
 defmodule BlockScoutWeb.API.V2.FeePaymentControllerTest do
   use BlockScoutWeb.ConnCase
 
-  alias Explorer.Chain.{Address, FeePayment, Wei}
+  alias Explorer.Chain.{Address, Block, FeePayment, Wei}
+  alias Explorer.Repo
 
   describe "/fee-payment" do
 
@@ -56,6 +57,7 @@ defmodule BlockScoutWeb.API.V2.FeePaymentControllerTest do
     assert fee_payment.block_number == json["block_number"]
     assert to_string(fee_payment.block_hash) == json["block_hash"]
     assert Wei.cast(json["value"]) == {:ok, fee_payment.value}
+    assert Jason.encode!(Repo.get_by(Block, hash: fee_payment.block_hash).timestamp) =~ String.replace(json["timestamp"], "Z", "")
   end
 
   defp check_paginated_response(first_page_resp, second_page_resp, list) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/forward_transfer_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/forward_transfer_controller_test.exs
@@ -1,7 +1,8 @@
 defmodule BlockScoutWeb.API.V2.ForwardTransferControllerTest do
   use BlockScoutWeb.ConnCase
 
-  alias Explorer.Chain.{Address, ForwardTransfer, Wei}
+  alias Explorer.Chain.{Address, Block, ForwardTransfer, Wei}
+  alias Explorer.Repo
 
   describe "/forward-transfers" do
 
@@ -56,6 +57,7 @@ defmodule BlockScoutWeb.API.V2.ForwardTransferControllerTest do
     assert forward_transfer.block_number == json["block_number"]
     assert to_string(forward_transfer.block_hash) == json["block_hash"]
     assert Wei.cast(json["value"]) == {:ok, forward_transfer.value}
+    assert Jason.encode!(Repo.get_by(Block, hash: forward_transfer.block_hash).timestamp) =~ String.replace(json["timestamp"], "Z", "")
   end
 
   defp check_paginated_response(first_page_resp, second_page_resp, list) do


### PR DESCRIPTION
Timestamp added to forward transfer and fee payments v2 responses. 
This PR involves the following V2 endpoints:
for **forward transfers**:

- all forward transfers: /api/v2/forward-transfers
- all forward transfers in block: /api/v2/blocks/<block-hash-or-number>/forward-transfers 
- all forward transfers per address: /api/v2/addresses/<address-hash>/forward-transfers 

for **fee payments**:
- all fee payments: /api/v2/fee-payments
- all fee payments in block: /api/v2/blocks/<block-hash-or-number>/fee-payments
- all fee payments per address: /api/v2/addresses/<address-hash>/fee-payments

Unit tests updated