### PR TITLE
Blockscout 3.5.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule BlockScout.Mixfile do
     [
       # app: :block_scout,
       # aliases: aliases(config_env()),
-      version: "3.5.0-RC2",
+      version: "3.5.0",
       apps_path: "apps",
       deps: deps(),
       dialyzer: dialyzer(),

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule BlockScout.Mixfile do
     [
       # app: :block_scout,
       # aliases: aliases(config_env()),
-      version: "3.5.0-RC1",
+      version: "3.5.0-RC2",
       apps_path: "apps",
       deps: deps(),
       dialyzer: dialyzer(),


### PR DESCRIPTION
Blockscout `3.5.0-RC2` was successfully tested in pregobi environment. This PR will be used to create the new `3.5.0` tag for gobi and EON release