### PR TITLE
WEB3-626 - epoch and block index columns added to blocks table

### DIFF
--- a/apps/explorer/priv/repo/migrations/20240410134411_add_epoch_and_block_index.exs
+++ b/apps/explorer/priv/repo/migrations/20240410134411_add_epoch_and_block_index.exs
@@ -1,0 +1,10 @@
+defmodule Explorer.Repo.Migrations.AddEpochAndBlockIndex do
+  use Ecto.Migration
+
+  def change do
+    alter table(:blocks) do
+      add(:epoch, :bigint, null: true)
+      add(:index, :bigint, null: true)
+    end
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20240410134411_add_epoch_and_block_index.exs
+++ b/apps/explorer/priv/repo/migrations/20240410134411_add_epoch_and_block_index.exs
@@ -4,7 +4,7 @@ defmodule Explorer.Repo.Migrations.AddEpochAndBlockIndex do
   def change do
     alter table(:blocks) do
       add(:epoch, :bigint, null: true)
-      add(:index, :bigint, null: true)
+      add(:slot_number, :bigint, null: true)
     end
   end
 end


### PR DESCRIPTION
In this PR epoch and block index columns are added to blocks table, they are nullable.