### PR TITLE
WEB3-659 - filter fee payments with value from mainchain greater than zero

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -438,6 +438,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
       @fee_payments_necessity_by_association
       |> Keyword.merge(paging_options(params))
       |> Keyword.merge(current_filter(params))
+      options = add_value_from_mainchain(options, params)
 
       results = Chain.get_fee_payments(address_hash, nil, options)
       {fee_payments, next_page} = split_list_by_page(results)
@@ -449,6 +450,14 @@ defmodule BlockScoutWeb.API.V2.AddressController do
       |> put_status(200)
       |> put_view(FeePaymentView)
       |> render(:fee_payments, %{fee_payments: fee_payments, next_page_params: next_page_params})
+    end
+  end
+
+  defp add_value_from_mainchain(options, params) do
+    value_from_mainchain = Enum.find_value(params, fn {key, _} -> key == "value_from_mainchain" end)
+    case value_from_mainchain do
+      nil -> options
+      _ -> Keyword.put_new(options, :value_from_mainchain, true)
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -171,6 +171,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
         @fee_payments_necessity_by_association
         |> Keyword.merge(paging_options(params))
         |> Keyword.merge(current_filter(params))
+      full_options = add_value_from_mainchain(full_options, params)
 
       result = Chain.get_fee_payments(nil, block.hash, full_options)
       {fee_payments, next_page} = split_list_by_page(result)
@@ -181,6 +182,14 @@ defmodule BlockScoutWeb.API.V2.BlockController do
       |> put_status(200)
       |> put_view(FeePaymentView)
       |> render(:fee_payments, %{fee_payments: fee_payments, next_page_params: next_page_params})
+    end
+  end
+
+  defp add_value_from_mainchain(options, params) do
+    value_from_mainchain = Enum.find_value(params, fn {key, _} -> key == "value_from_mainchain" end)
+    case value_from_mainchain do
+      nil -> options
+      _ -> Keyword.put_new(options, :value_from_mainchain, true)
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fee_payments_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fee_payments_controller.ex
@@ -29,6 +29,7 @@ defmodule BlockScoutWeb.API.V2.FeePaymentsController do
       @fee_payments_necessity_by_association
       |> Keyword.merge(paging_options(params))
       |> Keyword.merge(current_filter(params))
+    options = add_value_from_mainchain(options, params)
 
     results = Chain.get_fee_payments(nil, nil, options)
     {fee_payments, next_page} = split_list_by_page(results)
@@ -41,6 +42,16 @@ defmodule BlockScoutWeb.API.V2.FeePaymentsController do
     |> put_view(FeePaymentView)
     |> render(:fee_payments, %{fee_payments: fee_payments, next_page_params: next_page_params})
 
+  end
+
+  # check if "value_from_mainchain" parameter exists in params
+  # if the parameter exists, add it to options
+  defp add_value_from_mainchain(options, params) do
+    value_from_mainchain = Enum.find_value(params, fn {key, _} -> key == "value_from_mainchain" end)
+    case value_from_mainchain do
+      nil -> options
+      _ -> Keyword.put_new(options, :value_from_mainchain, true)
+    end
   end
 
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/fee_payment_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/fee_payment_view.ex
@@ -11,6 +11,8 @@ defmodule BlockScoutWeb.API.V2.FeePaymentView do
     %{
       "to_address" => Address.checksum(fee_payment.to_address_hash),
       "value" => fee_payment.value,
+      "value_from_fees" => fee_payment.value_from_fees,
+      "value_from_mainchain" => fee_payment.value_from_mainchain,
       "block_number" => fee_payment.block_number,
       "block_hash" => fee_payment.block_hash,
       "index" => fee_payment.index,

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -1710,6 +1710,25 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_1 == response
     end
 
+    # retrieve only fee payments with mainchain reward using value_from_mainchain query parameter
+    test "get fee payments with mainchain reward", %{conn: conn} do
+      address = insert(:address)
+      fee_payments = insert_list(3, :fee_payment_same_address, to_address: address)
+      fee_payments_with_no_mainchain_reward = insert_list(3, :fee_payment_same_address_no_mainchain_reward, to_address: address)
+      [fee_payment | _] = Enum.reverse(fee_payments)
+
+      request = get(conn, "/api/v2/addresses/#{address.hash}/fee-payments")
+      assert response = json_response(request, 200)
+      assert Enum.count(response["items"]) == 6
+      assert response["next_page_params"] == nil
+
+      request = get(conn, "/api/v2/addresses/#{address.hash}/fee-payments?value_from_mainchain=true")
+      assert response = json_response(request, 200)
+      assert Enum.count(response["items"]) == 3
+      assert response["next_page_params"] == nil
+      compare_item(fee_payment, Enum.at(response["items"], 0))
+    end
+
     test "get fee payments with working next_page_params", %{conn: conn} do
       address = insert(:address)
       fee_payments = insert_list(51, :fee_payment_same_address, to_address: address)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -1714,9 +1714,9 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
     test "get fee payments with mainchain reward", %{conn: conn} do
       address = insert(:address)
       fee_payments = insert_list(3, :fee_payment_same_address, to_address: address)
-      fee_payments_with_no_mainchain_reward = insert_list(3, :fee_payment_same_address_no_mainchain_reward, to_address: address)
-      address_two = insert(:address) # insert 3 fee payments related to a second address
-      fee_payments_with_no_mainchain_reward_address_two = insert_list(3, :fee_payment_same_address_no_mainchain_reward, to_address: address_two)
+      fee_payments_old_format = insert_list(3, :fee_payment_same_address_no_mainchain_reward, to_address: address)
+      address_two = insert(:address) # insert 3 fee payments with no mainchain reward related to a second address
+      fee_payments_old_format_address_two = insert_list(3, :fee_payment_same_address_no_mainchain_reward, to_address: address_two)
       [fee_payment | _] = Enum.reverse(fee_payments)
 
       request = get(conn, "/api/v2/addresses/#{address.hash}/fee-payments")

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -1864,6 +1864,8 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
     assert fee_payment.block_number == json["block_number"]
     assert to_string(fee_payment.block_hash) == json["block_hash"]
     assert Wei.cast(json["value"]) == {:ok, fee_payment.value}
+    assert Wei.cast(json["value_from_fees"]) == {:ok, fee_payment.value_from_fees}
+    assert Wei.cast(json["value_from_mainchain"]) == {:ok, fee_payment.value_from_mainchain}
     assert Jason.encode!(Repo.get_by(Block, hash: fee_payment.block_hash).timestamp) =~ String.replace(json["timestamp"], "Z", "")
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -1715,6 +1715,8 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       address = insert(:address)
       fee_payments = insert_list(3, :fee_payment_same_address, to_address: address)
       fee_payments_with_no_mainchain_reward = insert_list(3, :fee_payment_same_address_no_mainchain_reward, to_address: address)
+      address_two = insert(:address) # insert 3 fee payments related to a second address
+      fee_payments_with_no_mainchain_reward_address_two = insert_list(3, :fee_payment_same_address_no_mainchain_reward, to_address: address_two)
       [fee_payment | _] = Enum.reverse(fee_payments)
 
       request = get(conn, "/api/v2/addresses/#{address.hash}/fee-payments")
@@ -1727,6 +1729,16 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert Enum.count(response["items"]) == 3
       assert response["next_page_params"] == nil
       compare_item(fee_payment, Enum.at(response["items"], 0))
+
+      request = get(conn, "/api/v2/addresses/#{address_two.hash}/fee-payments")
+      assert response = json_response(request, 200)
+      assert Enum.count(response["items"]) == 3
+      assert response["next_page_params"] == nil
+
+      request = get(conn, "/api/v2/addresses/#{address_two.hash}/fee-payments?value_from_mainchain=true")
+      assert response = json_response(request, 200)
+      assert Enum.count(response["items"]) == 0
+      assert response["next_page_params"] == nil
     end
 
     test "get fee payments with working next_page_params", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -562,6 +562,8 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
     assert fee_payment.block_number == json["block_number"]
     assert to_string(fee_payment.block_hash) == json["block_hash"]
     assert Wei.cast(json["value"]) == {:ok, fee_payment.value}
+    assert Wei.cast(json["value_from_fees"]) == {:ok, fee_payment.value_from_fees}
+    assert Wei.cast(json["value_from_mainchain"]) == {:ok, fee_payment.value_from_mainchain}
     assert Jason.encode!(Repo.get_by(Block, hash: fee_payment.block_hash).timestamp) =~ String.replace(json["timestamp"], "Z", "")
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -510,6 +510,8 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
       block = insert(:block)
       fee_payments = insert_list(3, :fee_payment_same_block, block: block)
       fee_payments_with_no_mainchain_reward = insert_list(3, :fee_payment_same_block_no_mainchain_reward, block: block)
+      block_two = insert(:block) # insert 3 fee payments with no mainchain reward related to a second block
+      fee_payments_with_no_mainchain_reward = insert_list(3, :fee_payment_same_block_no_mainchain_reward, block: block_two)
       [fee_payment | _] = Enum.reverse(fee_payments)
 
       request = get(conn, "/api/v2/blocks/#{block.number}/fee-payments")
@@ -522,6 +524,16 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
       assert Enum.count(response["items"]) == 3
       assert response["next_page_params"] == nil
       compare_item(fee_payment, Enum.at(response["items"], 0))
+
+      request = get(conn, "/api/v2/blocks/#{block_two.number}/fee-payments")
+      assert response = json_response(request, 200)
+      assert Enum.count(response["items"]) == 3
+      assert response["next_page_params"] == nil
+
+      request = get(conn, "/api/v2/blocks/#{block_two.hash}/fee-payments?value_from_mainchain=true")
+      assert response = json_response(request, 200)
+      assert Enum.count(response["items"]) == 0
+      assert response["next_page_params"] == nil
     end
 
     test "get fee payments with working next_page_params", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -505,6 +505,25 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
       assert response_1 == response
     end
 
+    # retrieve only fee payments with mainchain reward using value_from_mainchain query parameter
+    test "get fee payments with mainchain reward", %{conn: conn} do
+      block = insert(:block)
+      fee_payments = insert_list(3, :fee_payment_same_block, block: block)
+      fee_payments_with_no_mainchain_reward = insert_list(3, :fee_payment_same_block_no_mainchain_reward, block: block)
+      [fee_payment | _] = Enum.reverse(fee_payments)
+
+      request = get(conn, "/api/v2/blocks/#{block.number}/fee-payments")
+      assert response = json_response(request, 200)
+      assert Enum.count(response["items"]) == 6
+      assert response["next_page_params"] == nil
+
+      request = get(conn, "/api/v2/blocks/#{block.hash}/fee-payments?value_from_mainchain=true")
+      assert response = json_response(request, 200)
+      assert Enum.count(response["items"]) == 3
+      assert response["next_page_params"] == nil
+      compare_item(fee_payment, Enum.at(response["items"], 0))
+    end
+
     test "get fee payments with working next_page_params", %{conn: conn} do
 
       block = insert(:block)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/fee_payment_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/fee_payment_controller_test.exs
@@ -57,6 +57,8 @@ defmodule BlockScoutWeb.API.V2.FeePaymentControllerTest do
     assert fee_payment.block_number == json["block_number"]
     assert to_string(fee_payment.block_hash) == json["block_hash"]
     assert Wei.cast(json["value"]) == {:ok, fee_payment.value}
+    assert Wei.cast(json["value_from_fees"]) == {:ok, fee_payment.value_from_fees}
+    assert Wei.cast(json["value_from_mainchain"]) == {:ok, fee_payment.value_from_mainchain}
     assert Jason.encode!(Repo.get_by(Block, hash: fee_payment.block_hash).timestamp) =~ String.replace(json["timestamp"], "Z", "")
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/fee_payment_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/fee_payment_controller_test.exs
@@ -29,12 +29,12 @@ defmodule BlockScoutWeb.API.V2.FeePaymentControllerTest do
     end
 
     # in this test 6 fee payments are inserted in the database:
-    # - 3 fee payments with mainchain reward (value_from_mainchain > 0 wei)
-    # - 3 fee payments with no mainchain reward
+    # - 3 fee payments with current format (value_from_fees and value_from_mainchain fields) and mainchain reward > 0 wei
+    # - 3 fee payments with old format (and so no mainchain reward present)
     # it check that only the 3 fee payments with mainchain reward are returned if the value_from_mainchain query param is present and set to true
     test "get fee payments with mainchain reward", %{conn: conn} do
       fee_payments = insert_list(3, :fee_payment)
-      fee_payments_with_no_mainchain_reward = insert_list(3, :fee_payment_no_mainchain_reward)
+      fee_payments_old_format = insert_list(3, :fee_payment_old_format)
       [fee_payment | _] = Enum.reverse(fee_payments)
 
       # return all fee payments

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/fee_payment_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/fee_payment_controller_test.exs
@@ -4,8 +4,6 @@ defmodule BlockScoutWeb.API.V2.FeePaymentControllerTest do
   alias Explorer.Chain.{Address, Block, FeePayment, Wei}
   alias Explorer.Repo
 
-  require Logger
-
   describe "/fee-payment" do
 
     test "get empty list", %{conn: conn} do

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3821,10 +3821,12 @@ end
   def get_fee_payments(address_hash \\ nil, block_hash \\ nil, options \\ []) when is_list(options) do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
+    value_from_mainchain = Keyword.get(options, :value_from_mainchain, false)
 
     FeePayment
     |> fee_payments_filter_address_hash(address_hash)
     |> fee_payments_filter_block_hash(block_hash)
+    |> fee_payments_filter_with_value_from_maichain(value_from_mainchain)
     |> order_by([fee_payment], desc: [fee_payment.block_number, fee_payment.index])
     |> handle_fee_payments_paging_options(paging_options)
     |> join_associations(necessity_by_association)
@@ -3840,6 +3842,12 @@ end
   defp fee_payments_filter_block_hash(query, block_hash) do
     query |> where([fp], fp.block_hash == ^block_hash)
   end
+
+  defp fee_payments_filter_with_value_from_maichain(query, true) do
+    zero_wei = %Wei{value: Decimal.new(0)}
+    query |> where([fp], fp.value_from_mainchain > ^zero_wei)
+  end
+  defp fee_payments_filter_with_value_from_maichain(query, _), do: query
 
   def fee_payments_count() do
     FeePayment

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3826,7 +3826,7 @@ end
     FeePayment
     |> fee_payments_filter_address_hash(address_hash)
     |> fee_payments_filter_block_hash(block_hash)
-    |> fee_payments_filter_with_value_from_maichain(value_from_mainchain)
+    |> fee_payments_filter_with_value_from_mainchain(value_from_mainchain)
     |> order_by([fee_payment], desc: [fee_payment.block_number, fee_payment.index])
     |> handle_fee_payments_paging_options(paging_options)
     |> join_associations(necessity_by_association)
@@ -3843,11 +3843,11 @@ end
     query |> where([fp], fp.block_hash == ^block_hash)
   end
 
-  defp fee_payments_filter_with_value_from_maichain(query, true) do
+  defp fee_payments_filter_with_value_from_mainchain(query, true) do
     zero_wei = %Wei{value: Decimal.new(0)}
     query |> where([fp], fp.value_from_mainchain > ^zero_wei)
   end
-  defp fee_payments_filter_with_value_from_maichain(query, _), do: query
+  defp fee_payments_filter_with_value_from_mainchain(query, _), do: query
 
   def fee_payments_count() do
     FeePayment

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -819,7 +819,7 @@ defmodule Explorer.Factory do
     }
   end
 
-  def fee_payment_no_mainchain_reward_factory do
+  def fee_payment_old_format_factory do
     block = insert(:block)
     address = insert(:address)
 
@@ -828,7 +828,6 @@ defmodule Explorer.Factory do
       block_hash: block.hash,
       to_address_hash: address.hash,
       value: Enum.random(1..100_000),
-      value_from_fees: Enum.random(1..100_000),
       index: fee_payment_index()
     }
   end
@@ -856,6 +855,7 @@ defmodule Explorer.Factory do
       to_address_hash: address.hash,
       value: Enum.random(1..100_000),
       value_from_fees: Enum.random(1..100_000),
+      value_from_mainchain: 0,
       index: fee_payment_index()
     }
   end
@@ -883,6 +883,7 @@ defmodule Explorer.Factory do
       to_address: build(:address),
       value: Enum.random(1..100_000),
       value_from_fees: Enum.random(1..100_000),
+      value_from_mainchain: 0,
       index: fee_payment_index()
     }
   end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -847,6 +847,19 @@ defmodule Explorer.Factory do
     }
   end
 
+  def fee_payment_same_block_no_mainchain_reward_factory do
+    address = insert(:address)
+
+    %FeePayment{
+      block: build(:block),
+      block_number: build(:block).number,
+      to_address_hash: address.hash,
+      value: Enum.random(1..100_000),
+      value_from_fees: Enum.random(1..100_000),
+      index: fee_payment_index()
+    }
+  end
+
   def fee_payment_same_address_factory do
     block = insert(:block)
 
@@ -857,6 +870,19 @@ defmodule Explorer.Factory do
       value: Enum.random(1..100_000),
       value_from_fees: Enum.random(1..100_000),
       value_from_mainchain: Enum.random(1..100_000),
+      index: fee_payment_index()
+    }
+  end
+
+  def fee_payment_same_address_no_mainchain_reward_factory do
+    block = insert(:block)
+
+    %FeePayment{
+      block_number: block.number,
+      block_hash: block.hash,
+      to_address: build(:address),
+      value: Enum.random(1..100_000),
+      value_from_fees: Enum.random(1..100_000),
       index: fee_payment_index()
     }
   end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -813,6 +813,8 @@ defmodule Explorer.Factory do
       block_hash: block.hash,
       to_address_hash: address.hash,
       value: Enum.random(1..100_000),
+      value_from_fees: Enum.random(1..100_000),
+      value_from_mainchain: Enum.random(1..100_000),
       index: fee_payment_index()
     }
   end
@@ -825,6 +827,8 @@ defmodule Explorer.Factory do
       block_number: build(:block).number,
       to_address_hash: address.hash,
       value: Enum.random(1..100_000),
+      value_from_fees: Enum.random(1..100_000),
+      value_from_mainchain: Enum.random(1..100_000),
       index: fee_payment_index()
     }
   end
@@ -837,6 +841,8 @@ defmodule Explorer.Factory do
       block_hash: block.hash,
       to_address: build(:address),
       value: Enum.random(1..100_000),
+      value_from_fees: Enum.random(1..100_000),
+      value_from_mainchain: Enum.random(1..100_000),
       index: fee_payment_index()
     }
   end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -819,6 +819,20 @@ defmodule Explorer.Factory do
     }
   end
 
+  def fee_payment_no_mainchain_reward_factory do
+    block = insert(:block)
+    address = insert(:address)
+
+    %FeePayment{
+      block_number: block.number,
+      block_hash: block.hash,
+      to_address_hash: address.hash,
+      value: Enum.random(1..100_000),
+      value_from_fees: Enum.random(1..100_000),
+      index: fee_payment_index()
+    }
+  end
+
   def fee_payment_same_block_factory do
     address = insert(:address)
 


### PR DESCRIPTION
In this PR:
- new fields `value_from_fees` and `value_from_mainchain` added to `v2` endpoints that return fee payments
- filter fee payments result with mainchain reward present and greater than zero using `value_from_mainchain` query param set to `true`
- `v2` unit tests updated