### PR TITLE
Increase error datatype size for txs and internal txs

### DIFF
--- a/apps/explorer/priv/repo/migrations/20240524134747_internal_transaction_error_text_datatype.exs
+++ b/apps/explorer/priv/repo/migrations/20240524134747_internal_transaction_error_text_datatype.exs
@@ -1,0 +1,12 @@
+defmodule Explorer.Repo.Migrations.InternalTransactionErrorTextDatatype do
+  use Ecto.Migration
+
+  def change do
+    alter table(:transactions) do
+      modify(:error, :text, null: true)
+    end
+    alter table(:internal_transactions) do
+      modify(:error, :text, null: true)
+    end
+  end
+end


### PR DESCRIPTION
After the EON 1.4.0 release on pregobi the explorer encountered some error field value from `debug_traceTransaction` rpc method with length greater then 255 characters, like this one for the transaction `0xa43fafe8bdeff14f2eaa337ad84b7ec55facf03a54fec34da797535741447df3`:
```
 "error": "Invalid mc signature H4/dgrH6xIEVH7jyFaVfQKe1e/5IxcIXO7vutZWdKffBYLLiNrJFs3zQ+qoJkLBtKLHTxTCahz5CNj+wxpJJcbY=: invocation = class io.horizen.account.state.Invocation{caller=0x0e4f99bf9ba9b075478dbc6f70c3b6d7a7e75848, callee=0x0000000000000000000088888888888888888888, value=0x0, input=579465dd7a746e0000000000000000000000000000000000000000000000000000000000543942593848345a3650654376394453717238364a4c7145485169776d51316d48342f64677248367849455648376a7946615666514b65310000000000000000652f3549786349584f377675745a57644b666642594c4c694e724a4673337a512b716f4a6b4c42744b4c485478544361687a35434e6a2b7778704a4a6362593d, gasPool.getUsedGas=25380, readOnly=NO}"
```
With this PR we introduce the increasing of the error field size modifying the datatype of the `error` column of the `transactions` and `internal_transactions` tables from `varchar(255)` to `text`.
There are no guidelines on the error field length even though the datatype used on the official blockscout repository suggesting that on the ethereum chain there are error value from the `debug_traceTransaction` with length max 255 characters.