### PR TITLE
Remove STOP opcode support by blockscout

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
@@ -273,7 +273,7 @@ defmodule EthereumJSONRPC.Geth do
          trace_address,
          inner?
        )
-       when type in ~w(CALL CALLCODE DELEGATECALL STATICCALL CREATE CREATE2 SELFDESTRUCT REWARD STOP) do
+       when type in ~w(CALL CALLCODE DELEGATECALL STATICCALL CREATE CREATE2 SELFDESTRUCT REWARD) do
     new_trace_address = [index | trace_address]
 
     formatted_call =

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth/call.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth/call.ex
@@ -511,31 +511,4 @@ defmodule EthereumJSONRPC.Geth.Call do
       value: value
     }
   end
-
-  defp elixir_to_internal_transaction_params(%{
-      "blockNumber" => block_number,
-      "transactionIndex" => transaction_index,
-      "transactionHash" => transaction_hash,
-      "index" => index,
-      "traceAddress" => trace_address,
-      "type" => "stop" = type,
-      "from" => from_address_hash,
-      "input" => input,
-      "gas" => gas,
-      "gasUsed" => gas_used
-    }) do
-  %{
-  block_number: block_number,
-  transaction_index: transaction_index,
-  transaction_hash: transaction_hash,
-  index: index,
-  trace_address: trace_address,
-  type: type,
-  from_address_hash: from_address_hash,
-  input: input,
-  gas: gas,
-  gas_used: gas_used
-  }
-  end
-
 end


### PR DESCRIPTION
With this PR the support for the `STOP` opcode returned by the rpc method `debug_traceTransaction` and introduced with the PR https://github.com/HorizenLabs/eon-explorer/pull/85 is removed.
After synch up with the EON team it was confirmed that the responses encountered in pregobi environment with `STOP` code were not correct and need to be fixed (task EON-1856)