### PR TITLE
WEB3-946 - new /v2/search/quick endpoint implementation

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -146,6 +146,7 @@ defmodule BlockScoutWeb.ApiRouter do
     scope "/search" do
       get("/", V2.SearchController, :search)
       get("/check-redirect", V2.SearchController, :check_redirect)
+      get("/quick", V2.SearchController, :quick_search)
     end
 
     scope "/config" do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/search_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/search_controller.ex
@@ -4,6 +4,10 @@ defmodule BlockScoutWeb.API.V2.SearchController do
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1, from_param: 1]
 
   alias Explorer.Chain
+  alias Explorer.Chain.Search
+  alias Explorer.PagingOptions
+
+  @api_true [api?: true]
 
   def search(conn, %{"q" => query} = params) do
     [paging_options: paging_options] = paging_options(params)
@@ -32,4 +36,13 @@ defmodule BlockScoutWeb.API.V2.SearchController do
     |> put_status(200)
     |> render(:search_results, %{result: result})
   end
+
+  def quick_search(conn, %{"q" => query}) do
+    search_results = Search.balanced_unpaginated_search(%PagingOptions{page_size: 50}, query, @api_true)
+
+    conn
+    |> put_status(200)
+    |> render(:search_results, %{search_results: search_results})
+  end
+
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
@@ -8,6 +8,10 @@ defmodule BlockScoutWeb.API.V2.SearchView do
     %{"items" => Enum.map(search_results, &prepare_search_result/1), "next_page_params" => next_page_params}
   end
 
+  def render("search_results.json", %{search_results: search_results}) do
+    Enum.map(search_results, &prepare_search_result/1)
+  end
+
   def render("search_results.json", %{result: {:ok, result}}) do
     Map.merge(%{"redirect" => true}, redirect_search_results(result))
   end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
@@ -2,7 +2,7 @@ defmodule BlockScoutWeb.API.V2.SearchView do
   use BlockScoutWeb, :view
 
   alias BlockScoutWeb.Endpoint
-  alias Explorer.Chain.{Address, Block, Transaction}
+  alias Explorer.Chain.{Address, Block, Transaction, Hash}
 
   def render("search_results.json", %{search_results: search_results, next_page_params: next_page_params}) do
     %{"items" => Enum.map(search_results, &prepare_search_result/1), "next_page_params" => next_page_params}
@@ -72,6 +72,7 @@ defmodule BlockScoutWeb.API.V2.SearchView do
     }
   end
 
+  defp hash_to_string(%Hash{bytes: bytes}), do: hash_to_string(bytes)
   defp hash_to_string(hash), do: "0x" <> Base.encode16(hash, case: :lower)
 
   defp redirect_search_results(%Address{} = item) do

--- a/apps/block_scout_web/mix.exs
+++ b/apps/block_scout_web/mix.exs
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.Mixfile do
 
   def project do
     [
-      version: "3.7.0",
+      version: "3.8.0-RC1",
       aliases: aliases(),
       app: :block_scout_web,
       build_path: "../../_build",

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
@@ -4,6 +4,8 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
   alias Explorer.Chain.{Address, Block}
   alias Explorer.Repo
 
+  import Logger
+
   setup do
     insert(:block)
     insert(:unique_smart_contract)
@@ -287,4 +289,50 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       %{"redirect" => false, "type" => nil, "parameter" => nil} = json_response(request, 200)
     end
   end
+
+  describe "/search/quick" do
+    test "check that all categories are in response list", %{conn: conn} do
+      name = "156000"
+
+      tags =
+        for _ <- 0..50 do
+          insert(:address_to_tag, tag: build(:address_tag, display_name: name))
+        end
+
+      contracts = insert_list(50, :smart_contract, name: name)
+      tokens = insert_list(50, :token, name: name)
+      blocks = [insert(:block, number: name, consensus: false), insert(:block, number: name)]
+
+      request = get(conn, "/api/v2/search/quick?q=#{name}")
+      assert response = json_response(request, 200)
+      assert Enum.count(response) == 50
+
+      assert response |> Enum.filter(fn x -> x["type"] == "label" end) |> Enum.map(fn x -> x["address"] end) ==
+               tags |> Enum.reverse() |> Enum.take(16) |> Enum.map(fn tag -> Address.checksum(tag.address.hash) end)
+
+      assert response |> Enum.filter(fn x -> x["type"] == "contract" end) |> Enum.map(fn x -> x["address"] end) ==
+               contracts
+               |> Enum.reverse()
+               |> Enum.take(16)
+               |> Enum.map(fn contract -> Address.checksum(contract.address_hash) end)
+
+      assert response |> Enum.filter(fn x -> x["type"] == "token" end) |> Enum.map(fn x -> x["address"] end) ==
+               tokens
+               |> Enum.reverse()
+               |> Enum.take(16)
+               |> Enum.map(fn token -> Address.checksum(token.contract_address_hash) end)
+
+      block_hashes = response |> Enum.filter(fn x -> x["type"] == "block" end) |> Enum.map(fn x -> x["block_hash"] end)
+
+      assert block_hashes == blocks |> Enum.reverse() |> Enum.map(fn block -> to_string(block.hash) end) ||
+               block_hashes == blocks |> Enum.map(fn block -> to_string(block.hash) end)
+    end
+
+    test "returns empty list and don't crash", %{conn: conn} do
+      request = get(conn, "/api/v2/search/quick?q=
+        ")
+      assert [] = json_response(request, 200)
+    end
+  end
+
 end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
@@ -4,8 +4,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
   alias Explorer.Chain.{Address, Block}
   alias Explorer.Repo
 
-  import Logger
-
   setup do
     insert(:block)
     insert(:unique_smart_contract)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
@@ -291,6 +291,45 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
   end
 
   describe "/search/quick" do
+
+    test "check address", %{conn: conn} do
+      address = insert(:address)
+      hash = Address.checksum(address.hash)
+      request = get(conn, "/api/v2/search/quick?q=#{hash}")
+      assert response = json_response(request, 200)
+      assert Enum.count(response) == 1
+      item = Enum.at(response, 0)
+      assert item["type"] == "address"
+      assert item["address"] == to_string(address.hash)
+      assert item["is_smart_contract_verified"] == false
+      assert item["url"] =~ to_string(address.hash)
+
+    end
+
+    test "check block", %{conn: conn} do
+      block = insert(:block)
+      hash = Address.checksum(block.hash)
+      request = get(conn, "/api/v2/search/quick?q=#{hash}")
+      assert response = json_response(request, 200)
+      assert Enum.count(response) == 1
+      item = Enum.at(response, 0)
+      assert item["type"] == "block"
+      assert item["block_number"] == block.number
+      assert item["block_hash"] == to_string(block.hash)
+      assert item["url"] =~ to_string(block.hash)
+    end
+
+    test "check transactions", %{conn: conn} do
+      transaction = insert(:transaction)
+      request = get(conn, "/api/v2/search/quick?q=#{transaction.hash}")
+      assert response = json_response(request, 200)
+      assert Enum.count(response) == 1
+      item = Enum.at(response, 0)
+      assert item["type"] == "transaction"
+      assert item["tx_hash"] == to_string(transaction.hash)
+      assert item["url"] =~ to_string(transaction.hash)
+    end
+
     test "check that all categories are in response list", %{conn: conn} do
       name = "156000"
 

--- a/apps/ethereum_jsonrpc/mix.exs
+++ b/apps/ethereum_jsonrpc/mix.exs
@@ -3,7 +3,7 @@ defmodule EthereumJsonrpc.MixProject do
 
   def project do
     [
-      version: "3.7.0",
+      version: "3.8.0-RC1",
       aliases: aliases(Mix.env()),
       app: :ethereum_jsonrpc,
       build_path: "../../_build",

--- a/apps/explorer/lib/explorer/chain/search.ex
+++ b/apps/explorer/lib/explorer/chain/search.ex
@@ -1,0 +1,589 @@
+defmodule Explorer.Chain.Search do
+  @moduledoc """
+    Search related functions
+  """
+  import Ecto.Query,
+    only: [
+      dynamic: 2,
+      from: 2,
+      limit: 2,
+      order_by: 3,
+      subquery: 1,
+      union: 2,
+      where: 3
+    ]
+
+  import Explorer.Chain, only: [select_repo: 1]
+  alias Explorer.{Chain, PagingOptions}
+  alias Explorer.Helper, as: ExplorerHelper
+  alias Explorer.Tags.{AddressTag, AddressToTag}
+
+  alias Explorer.Chain.{
+    Address,
+    Beacon.Blob,
+    Block,
+    DenormalizationHelper,
+    SmartContract,
+    Token,
+    Transaction,
+    UserOperation
+  }
+
+  @doc """
+    Search function used in web interface. Returns paginated search results
+  """
+  @spec joint_search(PagingOptions.t(), integer(), binary(), [Chain.api?()] | []) :: list
+  def joint_search(paging_options, offset, raw_string, options \\ []) do
+    string = String.trim(raw_string)
+
+    result =
+      case prepare_search_term(string) do
+        {:some, term} ->
+          query = base_joint_query(string, term)
+
+          ordered_query =
+            from(items in subquery(query),
+              order_by: [
+                desc: items.priority,
+                desc_nulls_last: items.circulating_market_cap,
+                desc_nulls_last: items.exchange_rate,
+                desc_nulls_last: items.holder_count,
+                asc: items.name,
+                desc: items.inserted_at
+              ],
+              limit: ^paging_options.page_size,
+              offset: ^offset
+            )
+
+          paginated_ordered_query =
+            ordered_query
+            |> page_search_results(paging_options)
+
+          search_results = select_repo(options).all(paginated_ordered_query)
+
+          search_results
+          |> Enum.map(fn result ->
+            result
+            |> compose_result_checksummed_address_hash()
+            |> format_timestamp()
+          end)
+
+        _ ->
+          []
+      end
+  end
+
+  def base_joint_query(string, term) do
+    tokens_query = search_token_query(string, term)
+    contracts_query = search_contract_query(term)
+    labels_query = search_label_query(term)
+    address_query = search_address_query(string)
+    block_query = search_block_query(string)
+
+    basic_query =
+      from(
+        tokens in subquery(tokens_query),
+        union: ^contracts_query,
+        union: ^labels_query
+      )
+
+    cond do
+      address_query ->
+        basic_query
+        |> union(^address_query)
+
+      valid_full_hash?(string) ->
+        tx_query = search_tx_query(string)
+
+        tx_block_query =
+          basic_query
+          |> union(^tx_query)
+          |> union(^block_query)
+
+        tx_block_op_query =
+          if UserOperation.enabled?() do
+            user_operation_query = search_user_operation_query(string)
+
+            tx_block_query
+            |> union(^user_operation_query)
+          else
+            tx_block_query
+          end
+
+        if Application.get_env(:explorer, :chain_type) == :ethereum do
+          blob_query = search_blob_query(string)
+
+          tx_block_op_query
+          |> union(^blob_query)
+        else
+          tx_block_op_query
+        end
+
+      block_query ->
+        basic_query
+        |> union(^block_query)
+
+      true ->
+        basic_query
+    end
+  end
+
+  @doc """
+    Search function. Differences from joint_search/4:
+      1. Returns all the found categories (amount of results up to `paging_options.page_size`).
+          For example if was found 50 tokens, 50 smart-contracts, 50 labels, 1 address, 1 transaction and 2 blocks (impossible, just example) and page_size=50. Then function will return:
+            [1 address, 1 transaction, 2 blocks, 16 tokens, 15 smart-contracts, 15 labels]
+      2. Results couldn't be paginated
+  """
+  @spec balanced_unpaginated_search(PagingOptions.t(), binary(), [Chain.api?()] | []) :: list
+  # credo:disable-for-next-line
+  def balanced_unpaginated_search(paging_options, raw_search_query, options \\ []) do
+    search_query = String.trim(raw_search_query)
+
+    case prepare_search_term(search_query) do
+      {:some, term} ->
+        tokens_result =
+          search_query
+          |> search_token_query(term)
+          |> order_by([token],
+            desc_nulls_last: token.circulating_market_cap,
+            desc_nulls_last: token.fiat_value,
+            desc_nulls_last: token.holder_count,
+            asc: token.name,
+            desc: token.inserted_at
+          )
+          |> limit(^paging_options.page_size)
+          |> select_repo(options).all()
+
+        contracts_result =
+          term
+          |> search_contract_query()
+          |> order_by([items], asc: items.name, desc: items.inserted_at)
+          |> limit(^paging_options.page_size)
+          |> select_repo(options).all()
+
+        labels_result =
+          term
+          |> search_label_query()
+          |> order_by([att, at], asc: at.display_name, desc: att.inserted_at)
+          |> limit(^paging_options.page_size)
+          |> select_repo(options).all()
+
+        tx_result =
+          if valid_full_hash?(search_query) do
+            search_query
+            |> search_tx_query()
+            |> select_repo(options).all()
+          else
+            []
+          end
+
+        op_result =
+          if valid_full_hash?(search_query) && UserOperation.enabled?() do
+            search_query
+            |> search_user_operation_query()
+            |> select_repo(options).all()
+          else
+            []
+          end
+
+        blob_result =
+          if valid_full_hash?(search_query) && Application.get_env(:explorer, :chain_type) == :ethereum do
+            search_query
+            |> search_blob_query()
+            |> select_repo(options).all()
+          else
+            []
+          end
+
+        address_result =
+          if query = search_address_query(search_query) do
+            query
+            |> select_repo(options).all()
+          else
+            []
+          end
+
+        blocks_result =
+          if query = search_block_query(search_query) do
+            query
+            |> limit(^paging_options.page_size)
+            |> select_repo(options).all()
+          else
+            []
+          end
+
+        non_empty_lists =
+          [
+            tokens_result,
+            contracts_result,
+            labels_result,
+            tx_result,
+            op_result,
+            blob_result,
+            address_result,
+            blocks_result,
+          ]
+          |> Enum.filter(fn list -> not Enum.empty?(list) end)
+          |> Enum.sort_by(fn list -> Enum.count(list) end, :asc)
+
+        to_take =
+          non_empty_lists
+          |> Enum.map(fn list -> Enum.count(list) end)
+          |> take_all_categories(List.duplicate(0, Enum.count(non_empty_lists)), paging_options.page_size)
+
+        non_empty_lists
+        |> Enum.zip_reduce(to_take, [], fn x, y, acc -> acc ++ Enum.take(x, y) end)
+        |> Enum.map(fn result ->
+          result
+          |> compose_result_checksummed_address_hash()
+          |> format_timestamp()
+        end)
+        |> Enum.sort_by(fn item -> item.priority end, :desc)
+
+      _ ->
+        []
+    end
+  end
+
+  def prepare_search_term(string) do
+    case Regex.scan(~r/[a-zA-Z0-9]+/, string) do
+      [_ | _] = words ->
+        term_final =
+          words
+          |> Enum.map_join(" & ", fn [word] -> word <> ":*" end)
+
+        {:some, term_final}
+
+      _ ->
+        :none
+    end
+  end
+
+  defp search_label_query(term) do
+    label_search_fields =
+      search_fields()
+      |> Map.put(:address_hash, dynamic([att, _, _], att.address_hash))
+      |> Map.put(:type, "label")
+      |> Map.put(:name, dynamic([_, at, _], at.display_name))
+      |> Map.put(:inserted_at, dynamic([att, _, _], att.inserted_at))
+      |> Map.put(:verified, dynamic([_, _, smart_contract], not is_nil(smart_contract)))
+      |> Map.put(:priority, 1)
+
+    inner_query =
+      from(tag in AddressTag,
+        where: fragment("to_tsvector('english', ?) @@ to_tsquery(?)", tag.display_name, ^term),
+        select: tag
+      )
+
+    from(att in AddressToTag,
+      inner_join: at in subquery(inner_query),
+      on: att.tag_id == at.id,
+      left_join: smart_contract in SmartContract,
+      on: att.address_hash == smart_contract.address_hash,
+      select: ^label_search_fields
+    )
+  end
+
+  defp search_token_query(string, term) do
+    token_search_fields =
+      search_fields()
+      |> Map.put(:address_hash, dynamic([token, _], token.contract_address_hash))
+      |> Map.put(:type, "token")
+      |> Map.put(:name, dynamic([token, _], token.name))
+      |> Map.put(:symbol, dynamic([token, _], token.symbol))
+      |> Map.put(:holder_count, dynamic([token, _], token.holder_count))
+      |> Map.put(:inserted_at, dynamic([token, _], token.inserted_at))
+      |> Map.put(:icon_url, dynamic([token, _], token.icon_url))
+      |> Map.put(:token_type, dynamic([token, _], token.type))
+      |> Map.put(:verified, dynamic([_, smart_contract], not is_nil(smart_contract)))
+      |> Map.put(:exchange_rate, dynamic([token, _], token.fiat_value))
+      |> Map.put(:total_supply, dynamic([token, _], token.total_supply))
+      |> Map.put(:circulating_market_cap, dynamic([token, _], token.circulating_market_cap))
+
+    case Chain.string_to_address_hash(string) do
+      {:ok, address_hash} ->
+        from(token in Token,
+          left_join: smart_contract in SmartContract,
+          on: token.contract_address_hash == smart_contract.address_hash,
+          where: token.contract_address_hash == ^address_hash,
+          select: ^token_search_fields
+        )
+
+      _ ->
+        from(token in Token,
+          left_join: smart_contract in SmartContract,
+          on: token.contract_address_hash == smart_contract.address_hash,
+          where: fragment("to_tsvector('english', ? || ' ' || ?) @@ to_tsquery(?)", token.symbol, token.name, ^term),
+          select: ^token_search_fields
+        )
+    end
+  end
+
+  defp search_contract_query(term) do
+    contract_search_fields =
+      search_fields()
+      |> Map.put(:address_hash, dynamic([smart_contract, _], smart_contract.address_hash))
+      |> Map.put(:type, "contract")
+      |> Map.put(:name, dynamic([smart_contract, _], smart_contract.name))
+      |> Map.put(:inserted_at, dynamic([_, address], address.inserted_at))
+      |> Map.put(:verified, true)
+
+    from(smart_contract in SmartContract,
+      left_join: address in Address,
+      on: smart_contract.address_hash == address.hash,
+      where: fragment("to_tsvector('english', ?) @@ to_tsquery(?)", smart_contract.name, ^term),
+      select: ^contract_search_fields
+    )
+  end
+
+  defp search_address_query(term) do
+    case Chain.string_to_address_hash(term) do
+      {:ok, address_hash} ->
+        address_search_fields =
+          search_fields()
+          |> Map.put(:address_hash, dynamic([address, _, _], address.hash))
+          |> Map.put(:type, "address")
+          |> Map.put(:name, dynamic([_, address_name, _], address_name.name))
+          |> Map.put(:inserted_at, dynamic([_, address_name, _], address_name.inserted_at))
+          |> Map.put(:verified, dynamic([address, _, _], address.verified))
+
+        from(address in Address,
+          left_join:
+            address_name in subquery(
+              from(name in Address.Name,
+                where: name.address_hash == ^address_hash,
+                order_by: [desc: name.primary],
+                limit: 1
+              )
+            ),
+          on: address.hash == address_name.address_hash,
+          left_join: smart_contract in SmartContract,
+          on: address.hash == smart_contract.address_hash,
+          where: address.hash == ^address_hash,
+          select: ^address_search_fields
+        )
+
+      _ ->
+        nil
+    end
+  end
+
+  defp valid_full_hash?(string_input) do
+    case Chain.string_to_transaction_hash(string_input) do
+      {:ok, _tx_hash} -> true
+      _ -> false
+    end
+  end
+
+  defp search_tx_query(term) do
+    if DenormalizationHelper.transactions_denormalization_finished?() do
+      transaction_search_fields =
+        search_fields()
+        |> Map.put(:tx_hash, dynamic([transaction], transaction.hash))
+        |> Map.put(:block_hash, dynamic([transaction], transaction.block_hash))
+        |> Map.put(:type, "transaction")
+        |> Map.put(:block_number, dynamic([transaction], transaction.block_number))
+        |> Map.put(:inserted_at, dynamic([transaction], transaction.inserted_at))
+        |> Map.put(:timestamp, dynamic([transaction], transaction.block_timestamp))
+
+      from(transaction in Transaction,
+        where: transaction.hash == ^term,
+        select: ^transaction_search_fields
+      )
+    else
+      transaction_search_fields =
+        search_fields()
+        |> Map.put(:tx_hash, dynamic([transaction, _], transaction.hash))
+        |> Map.put(:block_hash, dynamic([transaction, _], transaction.block_hash))
+        |> Map.put(:type, "transaction")
+        |> Map.put(:block_number, dynamic([transaction, _], transaction.block_number))
+        |> Map.put(:inserted_at, dynamic([transaction, _], transaction.inserted_at))
+        |> Map.put(:timestamp, dynamic([_, block], block.timestamp))
+
+      from(transaction in Transaction,
+        left_join: block in Block,
+        on: transaction.block_hash == block.hash,
+        where: transaction.hash == ^term,
+        select: ^transaction_search_fields
+      )
+    end
+  end
+
+  defp search_user_operation_query(term) do
+    user_operation_search_fields =
+      search_fields()
+      |> Map.put(:user_operation_hash, dynamic([user_operation, _], user_operation.hash))
+      |> Map.put(:block_hash, dynamic([user_operation, _], user_operation.block_hash))
+      |> Map.put(:type, "user_operation")
+      |> Map.put(:inserted_at, dynamic([user_operation, _], user_operation.inserted_at))
+      |> Map.put(:block_number, dynamic([user_operation, _], user_operation.block_number))
+      |> Map.put(:timestamp, dynamic([_, block], block.timestamp))
+
+    from(user_operation in UserOperation,
+      left_join: block in Block,
+      on: user_operation.block_hash == block.hash,
+      where: user_operation.hash == ^term,
+      select: ^user_operation_search_fields
+    )
+  end
+
+  defp search_blob_query(term) do
+    blob_search_fields =
+      search_fields()
+      |> Map.put(:blob_hash, dynamic([blob, _], blob.hash))
+      |> Map.put(:type, "blob")
+      |> Map.put(:inserted_at, dynamic([blob, _], blob.inserted_at))
+
+    from(blob in Blob,
+      where: blob.hash == ^term,
+      select: ^blob_search_fields
+    )
+  end
+
+  defp search_block_query(term) do
+    block_search_fields =
+      search_fields()
+      |> Map.put(:block_hash, dynamic([block], block.hash))
+      |> Map.put(:type, "block")
+      |> Map.put(:block_number, dynamic([block], block.number))
+      |> Map.put(:inserted_at, dynamic([block], block.inserted_at))
+      |> Map.put(:timestamp, dynamic([block], block.timestamp))
+
+    case Chain.string_to_block_hash(term) do
+      {:ok, block_hash} ->
+        from(block in Block,
+          where: block.hash == ^block_hash,
+          select: ^block_search_fields
+        )
+
+      _ ->
+        case ExplorerHelper.safe_parse_non_negative_integer(term) do
+          {:ok, block_number} ->
+            from(block in Block,
+              where: block.number == ^block_number,
+              select: ^block_search_fields
+            )
+
+          _ ->
+            nil
+        end
+    end
+  end
+
+  defp page_search_results(query, %PagingOptions{key: nil}), do: query
+
+  defp page_search_results(query, %PagingOptions{
+         key: {_address_hash, _tx_hash, _block_hash, holder_count, name, inserted_at, item_type}
+       })
+       when holder_count in [nil, ""] do
+    where(
+      query,
+      [item],
+      (item.name > ^name and item.type == ^item_type) or
+        (item.name == ^name and item.inserted_at < ^inserted_at and
+           item.type == ^item_type) or
+        item.type != ^item_type
+    )
+  end
+
+  # credo:disable-for-next-line
+  defp page_search_results(query, %PagingOptions{
+         key: {_address_hash, _tx_hash, _block_hash, holder_count, name, inserted_at, item_type}
+       }) do
+    where(
+      query,
+      [item],
+      (item.holder_count < ^holder_count and item.type == ^item_type) or
+        (item.holder_count == ^holder_count and item.name > ^name and item.type == ^item_type) or
+        (item.holder_count == ^holder_count and item.name == ^name and item.inserted_at < ^inserted_at and
+           item.type == ^item_type) or
+        item.type != ^item_type
+    )
+  end
+
+  defp take_all_categories([], taken_lengths, _remained), do: taken_lengths
+
+  defp take_all_categories(lengths, taken_lengths, remained) do
+    non_zero_count = count_non_zero(lengths)
+
+    target = if(remained < non_zero_count, do: 1, else: div(remained, non_zero_count))
+
+    {lengths_updated, %{result: taken_lengths_reversed}} =
+      Enum.map_reduce(lengths, %{result: [], sum: 0}, fn el, acc ->
+        taken =
+          cond do
+            acc[:sum] >= remained ->
+              0
+
+            el < target ->
+              el
+
+            true ->
+              target
+          end
+
+        {el - taken, %{result: [taken | acc[:result]], sum: acc[:sum] + taken}}
+      end)
+
+    taken_lengths =
+      taken_lengths
+      |> Enum.zip_reduce(Enum.reverse(taken_lengths_reversed), [], fn x, y, acc -> [x + y | acc] end)
+      |> Enum.reverse()
+
+    remained = remained - Enum.sum(taken_lengths_reversed)
+
+    if remained > 0 and count_non_zero(lengths_updated) > 0 do
+      take_all_categories(lengths_updated, taken_lengths, remained)
+    else
+      taken_lengths
+    end
+  end
+
+  defp count_non_zero(list) do
+    Enum.reduce(list, 0, fn el, acc -> acc + if el > 0, do: 1, else: 0 end)
+  end
+
+  defp compose_result_checksummed_address_hash(result) do
+    if result.address_hash do
+      result
+      |> Map.put(:address_hash, Address.checksum(result.address_hash))
+    else
+      result
+    end
+  end
+
+  # For some reasons timestamp for blocks and txs returns as ~N[2023-06-25 19:39:47.339493]
+  defp format_timestamp(result) do
+    if result.timestamp do
+      result
+      |> Map.put(:timestamp, DateTime.from_naive!(result.timestamp, "Etc/UTC"))
+    else
+      result
+    end
+  end
+
+  defp search_fields do
+    %{
+      address_hash: dynamic([_], type(^nil, :binary)),
+      tx_hash: dynamic([_], type(^nil, :binary)),
+      user_operation_hash: dynamic([_], type(^nil, :binary)),
+      blob_hash: dynamic([_], type(^nil, :binary)),
+      block_hash: dynamic([_], type(^nil, :binary)),
+      type: nil,
+      name: nil,
+      symbol: nil,
+      holder_count: nil,
+      inserted_at: nil,
+      block_number: 0,
+      icon_url: nil,
+      token_type: nil,
+      timestamp: dynamic([_, _], type(^nil, :utc_datetime_usec)),
+      verified: nil,
+      exchange_rate: nil,
+      total_supply: nil,
+      circulating_market_cap: nil,
+      priority: 0
+    }
+  end
+end

--- a/apps/explorer/lib/explorer/helper.ex
+++ b/apps/explorer/lib/explorer/helper.ex
@@ -3,6 +3,8 @@ defmodule Explorer.Helper do
   Common explorer helper
   """
 
+  @max_safe_integer round(:math.pow(2, 63)) - 1
+
   def parse_integer(nil), do: nil
 
   def parse_integer(string) do
@@ -11,4 +13,34 @@ defmodule Explorer.Helper do
       _ -> nil
     end
   end
+
+    @doc """
+    Converts a string to an integer, ensuring it's non-negative and within the
+    acceptable range for database insertion.
+
+    ## Examples
+
+        iex> safe_parse_non_negative_integer("0")
+        {:ok, 0}
+
+        iex> safe_parse_non_negative_integer("-1")
+        {:error, :negative_integer}
+
+        iex> safe_parse_non_negative_integer("27606393966689717254124294199939478533331961967491413693980084341759630764504")
+        {:error, :too_big_integer}
+  """
+  def safe_parse_non_negative_integer(string) do
+    case Integer.parse(string) do
+      {num, ""} ->
+        case num do
+          _ when num > @max_safe_integer -> {:error, :too_big_integer}
+          _ when num < 0 -> {:error, :negative_integer}
+          _ -> {:ok, num}
+        end
+
+      _ ->
+        {:error, :invalid_integer}
+    end
+  end
+
 end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -1117,4 +1117,12 @@ defmodule Explorer.Factory do
   end
 
   def random_bool, do: Enum.random([true, false])
+
+  def address_tag_factory do
+    %AddressTag{
+      label: sequence("label"),
+      display_name: sequence("display_name")
+    }
+  end
+
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule BlockScout.Mixfile do
     [
       # app: :block_scout,
       # aliases: aliases(config_env()),
-      version: "3.7.0",
+      version: "3.8.0-RC1",
       apps_path: "apps",
       deps: deps(),
       dialyzer: dialyzer(),


### PR DESCRIPTION
New `/v2/search/quick` endpoint added, this endpoint is used with the `/v2/search/check-redirect` to provide results on the new frontend search bar.
Unit test updated.