### PR TITLE
WEB3-994 - Upgrade to eon-explorer version 3.8.0

### DIFF
--- a/apps/block_scout_web/mix.exs
+++ b/apps/block_scout_web/mix.exs
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.Mixfile do
 
   def project do
     [
-      version: "3.8.0-RC1",
+      version: "3.8.0",
       aliases: aliases(),
       app: :block_scout_web,
       build_path: "../../_build",

--- a/apps/ethereum_jsonrpc/mix.exs
+++ b/apps/ethereum_jsonrpc/mix.exs
@@ -3,7 +3,7 @@ defmodule EthereumJsonrpc.MixProject do
 
   def project do
     [
-      version: "3.8.0-RC1",
+      version: "3.8.0",
       aliases: aliases(Mix.env()),
       app: :ethereum_jsonrpc,
       build_path: "../../_build",

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule BlockScout.Mixfile do
     [
       # app: :block_scout,
       # aliases: aliases(config_env()),
-      version: "3.8.0-RC1",
+      version: "3.8.0",
       apps_path: "apps",
       deps: deps(),
       dialyzer: dialyzer(),


### PR DESCRIPTION
In this pull request:
- upgrade to eon-explorer version 3.8.0 for Gobi and EON release